### PR TITLE
bufix(gpuPowerAttrib): fix incorrect GPU power attribution in multi-GPU nvidia environments

### DIFF
--- a/cmd/node-exporter/main_test.go
+++ b/cmd/node-exporter/main_test.go
@@ -1,0 +1,184 @@
+package main
+
+import (
+	"bufio"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// TestParseBaseFrequencyFromCPUInfo tests the core frequency parsing logic
+func TestParseBaseFrequencyFromCPUInfo(t *testing.T) {
+	tests := []struct {
+		name     string
+		cpuInfo  string
+		expected float64
+	}{
+		{
+			name: "Extract from MHz line",
+			cpuInfo: `
+processor       : 0
+vendor_id       : GenuineIntel
+cpu family      : 6
+model           : 142
+model name      : Intel(R) Core(TM) i7-8565U CPU @ 1.80GHz
+stepping        : 11
+microcode       : 0xde
+cpu MHz         : 2400.000
+cache size      : 8192 KB
+`,
+			expected: 2.4, // 2400.000 MHz = 2.4 GHz
+		},
+		{
+			name: "Extract from model name",
+			cpuInfo: `
+processor       : 0
+vendor_id       : GenuineIntel
+cpu family      : 6
+model           : 142
+model name      : Intel(R) Core(TM) i7-8565U CPU @ 3.60GHz
+stepping        : 11
+microcode       : 0xde
+cache size      : 8192 KB
+`,
+			expected: 3.6, // 3.60GHz = 3.6 GHz
+		},
+		{
+			name: "No frequency information",
+			cpuInfo: `
+processor       : 0
+vendor_id       : GenuineIntel
+cpu family      : 6
+model           : 142
+stepping        : 11
+microcode       : 0xde
+cache size      : 8192 KB
+`,
+			expected: 0.0, // No frequency info
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create a test version of estimateBaseFrequencyFromCPUInfo that
+			// uses a string reader instead of file I/O
+			result := parseFrequencyInfo(strings.NewReader(tc.cpuInfo))
+			if result != tc.expected {
+				t.Errorf("parseFrequencyInfo() = %v, want %v", result, tc.expected)
+			}
+		})
+	}
+}
+
+// Test that extracts model info from cpuinfo data
+func TestParseCPUModelInfo(t *testing.T) {
+	cpuInfo := `
+processor       : 0
+vendor_id       : GenuineIntel
+cpu family      : 6
+model           : 142
+model name      : Intel(R) Core(TM) i7-8565U CPU @ 1.80GHz
+stepping        : 11
+microcode       : 0xde
+cpu MHz         : 2000.000
+cache size      : 8192 KB
+`
+
+	model, vendor, family := parseCPUModelInfoFromString(cpuInfo)
+
+	expectedModel := "Intel(R) Core(TM) i7-8565U CPU @ 1.80GHz"
+	expectedVendor := "GenuineIntel"
+	expectedFamily := "6"
+
+	if model != expectedModel {
+		t.Errorf("parseCPUModelInfoFromString() model = %v, want %v", model, expectedModel)
+	}
+	if vendor != expectedVendor {
+		t.Errorf("parseCPUModelInfoFromString() vendor = %v, want %v", vendor, expectedVendor)
+	}
+	if family != expectedFamily {
+		t.Errorf("parseCPUModelInfoFromString() family = %v, want %v", family, expectedFamily)
+	}
+}
+
+// Helper functions for testing - these would extract the core logic from the production functions
+
+// parseFrequencyInfo extracts CPU frequency from a reader (for testing)
+func parseFrequencyInfo(reader *strings.Reader) float64 {
+	scanner := bufio.NewScanner(reader)
+
+	// First try to find the cpu MHz line
+	var mhzFreq float64
+	var modelNameFreq float64
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		// Look for the "cpu MHz" line
+		if strings.Contains(line, "cpu MHz") {
+			parts := strings.Split(line, ":")
+			if len(parts) >= 2 {
+				freq, err := strconv.ParseFloat(strings.TrimSpace(parts[1]), 64)
+				if err == nil {
+					// Convert MHz to GHz
+					mhzFreq = freq / 1000
+				}
+			}
+		}
+
+		// Also check for "model name" in case it contains the frequency
+		if strings.Contains(line, "model name") && strings.Contains(line, "GHz") {
+			// Extract the frequency if it's in the model name (like "Intel i7 @ 2.60GHz")
+			parts := strings.Split(line, "@")
+			if len(parts) >= 2 {
+				// Find the GHz value
+				ghzPart := parts[1]
+				ghzPart = strings.TrimSpace(ghzPart)
+				ghzPart = strings.Split(ghzPart, " ")[0] // Get just the number
+				ghzPart = strings.Replace(ghzPart, "GHz", "", 1)
+
+				freq, err := strconv.ParseFloat(ghzPart, 64)
+				if err == nil {
+					modelNameFreq = freq
+				}
+			}
+		}
+	}
+
+	// Prefer the explicit MHz value if available
+	if mhzFreq > 0 {
+		return mhzFreq
+	}
+
+	// Otherwise use the model name frequency
+	if modelNameFreq > 0 {
+		return modelNameFreq
+	}
+
+	return 0
+}
+
+// parseCPUModelInfoFromString parses CPU model info from a string (for testing)
+func parseCPUModelInfoFromString(cpuInfo string) (model, vendor, family string) {
+	scanner := bufio.NewScanner(strings.NewReader(cpuInfo))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.Contains(line, "model name") {
+			parts := strings.Split(line, ":")
+			if len(parts) >= 2 {
+				model = strings.TrimSpace(parts[1])
+			}
+		} else if strings.Contains(line, "vendor_id") {
+			parts := strings.Split(line, ":")
+			if len(parts) >= 2 {
+				vendor = strings.TrimSpace(parts[1])
+			}
+		} else if strings.Contains(line, "cpu family") {
+			parts := strings.Split(line, ":")
+			if len(parts) >= 2 {
+				family = strings.TrimSpace(parts[1])
+			}
+		}
+	}
+	return model, vendor, family
+}

--- a/pkg/computegardener/metrics/metrics.go
+++ b/pkg/computegardener/metrics/metrics.go
@@ -241,6 +241,17 @@ var (
 		},
 		[]string{"namespace", "owner_kind", "action"},
 	)
+
+	// NodeTotalPowerEstimate estimates the total power consumption of an entire node
+	NodeTotalPowerEstimate = metrics.NewGaugeVec(
+		&metrics.GaugeOpts{
+			Subsystem:      schedulerSubsystem,
+			Name:           "node_total_power_estimate_watts",
+			Help:           "Estimated total power consumption in watts for an entire node (CPU + Mem + All GPUs)",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"node"}, // Labeled only by node
+	)
 )
 
 func init() {
@@ -266,4 +277,5 @@ func init() {
 	legacyregistry.MustRegister(NodeEfficiency)
 	legacyregistry.MustRegister(EnergyBudgetTracking)
 	legacyregistry.MustRegister(EnergyBudgetExceeded)
+	legacyregistry.MustRegister(NodeTotalPowerEstimate)
 }

--- a/pkg/computegardener/scheduler.go
+++ b/pkg/computegardener/scheduler.go
@@ -196,12 +196,12 @@ func New(ctx context.Context, obj runtime.Object, h framework.Handle) (framework
 
 		// Initialize GPU metrics client - use Prometheus if configured, otherwise use null client
 		if cfg.Metrics.Prometheus != nil && cfg.Metrics.Prometheus.URL != "" {
-			klog.InfoS("Initializing Prometheus GPU metrics client",
+			klog.InfoS("Initializing Prometheus metrics client",
 				"url", cfg.Metrics.Prometheus.URL)
 
-			promClient, err := metrics.NewPrometheusGPUMetricsClient(cfg.Metrics.Prometheus.URL)
+			promClient, err := metrics.NewPrometheusMetricsClient(cfg.Metrics.Prometheus.URL)
 			if err != nil {
-				klog.ErrorS(err, "Failed to initialize Prometheus GPU metrics client, falling back to null implementation")
+				klog.ErrorS(err, "Failed to initialize Prometheus metrics client, falling back to null implementation")
 				gpuMetricsClient = metrics.NewNullGPUMetricsClient()
 			} else {
 				// Configure DCGM metrics if settings are provided

--- a/pkg/computegardener/scheduler_metrics_collection_test.go
+++ b/pkg/computegardener/scheduler_metrics_collection_test.go
@@ -1,0 +1,139 @@
+package computegardener
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestGetAssignedGPUUUIDs(t *testing.T) {
+	tests := []struct {
+		name             string
+		envValue         string
+		expectedResult   []string
+		expectNil        bool
+		expectEmptySlice bool
+	}{
+		{
+			name:             "no environment variable",
+			envValue:         "",
+			expectedResult:   nil,
+			expectNil:        true,
+			expectEmptySlice: false,
+		},
+		{
+			name:             "empty value",
+			envValue:         "",
+			expectedResult:   []string{},
+			expectNil:        false,
+			expectEmptySlice: true,
+		},
+		{
+			name:             "none",
+			envValue:         "none",
+			expectedResult:   []string{},
+			expectNil:        false,
+			expectEmptySlice: true,
+		},
+		{
+			name:             "all",
+			envValue:         "all",
+			expectedResult:   []string{"all"},
+			expectNil:        false,
+			expectEmptySlice: false,
+		},
+		{
+			name:             "single UUID",
+			envValue:         "GPU-e0b9c0ec-3a68-cd5f-c41f-5c9466dcd83e",
+			expectedResult:   []string{"GPU-e0b9c0ec-3a68-cd5f-c41f-5c9466dcd83e"},
+			expectNil:        false,
+			expectEmptySlice: false,
+		},
+		{
+			name:             "multiple UUIDs",
+			envValue:         "GPU-e0b9c0ec-3a68-cd5f-c41f-5c9466dcd83e,GPU-a1b2c3d4-5e6f-7g8h-9i0j-1k2l3m4n5o6p",
+			expectedResult:   []string{"GPU-e0b9c0ec-3a68-cd5f-c41f-5c9466dcd83e", "GPU-a1b2c3d4-5e6f-7g8h-9i0j-1k2l3m4n5o6p"},
+			expectNil:        false,
+			expectEmptySlice: false,
+		},
+		{
+			name:             "numeric indices",
+			envValue:         "0,1",
+			expectedResult:   []string{"indices:0,1"},
+			expectNil:        false,
+			expectEmptySlice: false,
+		},
+		{
+			name:             "single numeric index",
+			envValue:         "0",
+			expectedResult:   []string{"indices:0"},
+			expectNil:        false,
+			expectEmptySlice: false,
+		},
+		{
+			name:             "mixed numeric and UUID", // Not expected in real-world, but ensure basic handling if ever encountered.
+			envValue:         "0,GPU-e0b9c0ec-3a68-cd5f-c41f-5c9466dcd83e",
+			expectedResult:   []string{"0", "GPU-e0b9c0ec-3a68-cd5f-c41f-5c9466dcd83e"},
+			expectNil:        false,
+			expectEmptySlice: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name: "test-container",
+							Env:  []v1.EnvVar{},
+						},
+					},
+				},
+			}
+
+			// For the "no environment variable" test, don't add the env var
+			if tt.name != "no environment variable" {
+				pod.Spec.Containers[0].Env = []v1.EnvVar{
+					{
+						Name:  "NVIDIA_VISIBLE_DEVICES",
+						Value: tt.envValue,
+					},
+				}
+			}
+
+			result := getAssignedGPUUUIDs(pod)
+
+			// Check nil specifically
+			if tt.expectNil && result != nil {
+				t.Errorf("Expected nil result, got %v", result)
+				return
+			}
+
+			// Check empty slice specifically
+			if tt.expectEmptySlice && (result == nil || len(result) != 0) {
+				t.Errorf("Expected empty slice, got %v", result)
+				return
+			}
+
+			// For non-nil and non-empty cases, check the expected result
+			if !tt.expectNil && !tt.expectEmptySlice {
+				if len(result) != len(tt.expectedResult) {
+					t.Errorf("Expected result length %d, got %d", len(tt.expectedResult), len(result))
+					return
+				}
+
+				for i, v := range result {
+					if v != tt.expectedResult[i] {
+						t.Errorf("Expected result[%d]=%s, got %s", i, tt.expectedResult[i], v)
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
#13

determine GPUs on a per pod basis using a runtime injected env var, maintain mapping from pod thru to one or more GPUs