### PR TITLE
feature(annotations): remove annotations redundant wrt NFD labels

### DIFF
--- a/cmd/node-exporter/main.go
+++ b/cmd/node-exporter/main.go
@@ -357,8 +357,8 @@ func getCPUModelInfo() (model, vendor, family string, err error) {
 	return model, vendor, family, nil
 }
 
-// updateNodeCPUModelLabel adds CPU model information to the node as NFD compatible labels
-func updateNodeCPUModelLabel(clientset *kubernetes.Clientset, nodeName string) error {
+// updateCPUModelLabel adds CPU model information to the node as NFD compatible labels
+func updateCPUModelLabel(clientset *kubernetes.Clientset, nodeName string) error {
 	// Get CPU model info
 	cpuModel, cpuVendor, cpuFamily, err := getCPUModelInfo()
 	if err != nil {
@@ -471,7 +471,7 @@ func main() {
 	}
 
 	// Annotate the node with CPU model info
-	if err := updateNodeCPUModelLabel(clientset, nodeName); err != nil {
+	if err := updateCPUModelLabel(clientset, nodeName); err != nil {
 		klog.ErrorS(err, "Failed to annotate node with CPU model information")
 		// Continue running even if annotation fails
 	}

--- a/cmd/node-exporter/main.go
+++ b/cmd/node-exporter/main.go
@@ -357,8 +357,8 @@ func getCPUModelInfo() (model, vendor, family string, err error) {
 	return model, vendor, family, nil
 }
 
-// annotateCPUModel adds CPU model information to the node as annotations
-func annotateCPUModel(clientset *kubernetes.Clientset, nodeName string) error {
+// updateNodeCPUModelLabel adds CPU model information to the node as NFD compatible labels
+func updateNodeCPUModelLabel(clientset *kubernetes.Clientset, nodeName string) error {
 	// Get CPU model info
 	cpuModel, cpuVendor, cpuFamily, err := getCPUModelInfo()
 	if err != nil {
@@ -378,30 +378,30 @@ func annotateCPUModel(clientset *kubernetes.Clientset, nodeName string) error {
 		return fmt.Errorf("failed to get node %s: %v", nodeName, err)
 	}
 
-	// Check if annotations already exist and match
-	if val, exists := node.Annotations[common.AnnotationCPUModel]; exists && val == cpuModel {
-		klog.V(2).InfoS("Node already has correct CPU model annotation",
+	// Check if label already exists and matches
+	if val, exists := node.Labels[common.NFDLabelCPUModel]; exists && val == cpuModel {
+		klog.V(2).InfoS("Node already has correct CPU model label",
 			"node", nodeName,
 			"model", cpuModel)
 		return nil
 	}
 
-	// Create a copy of the node with updated annotations
+	// Create a copy of the node with updated labels
 	nodeCopy := node.DeepCopy()
-	if nodeCopy.Annotations == nil {
-		nodeCopy.Annotations = make(map[string]string)
+	if nodeCopy.Labels == nil {
+		nodeCopy.Labels = make(map[string]string)
 	}
 
-	// Add annotations
-	nodeCopy.Annotations[common.AnnotationCPUModel] = cpuModel
+	// Add NFD-compatible labels
+	nodeCopy.Labels[common.NFDLabelCPUModel] = cpuModel
 
 	// Update the node
 	_, err = clientset.CoreV1().Nodes().Update(context.Background(), nodeCopy, metav1.UpdateOptions{})
 	if err != nil {
-		return fmt.Errorf("failed to update node annotations: %v", err)
+		return fmt.Errorf("failed to update node labels: %v", err)
 	}
 
-	klog.InfoS("Successfully annotated node with CPU model information",
+	klog.InfoS("Successfully updated node with CPU model label",
 		"node", nodeName,
 		"model", cpuModel)
 
@@ -410,16 +410,14 @@ func annotateCPUModel(clientset *kubernetes.Clientset, nodeName string) error {
 
 func main() {
 	var (
-		metricsAddr  string
-		kubeconfig   string
-		nodeName     string
-		annotateOnly bool
+		metricsAddr string
+		kubeconfig  string
+		nodeName    string
 	)
 
 	flag.StringVar(&metricsAddr, "metrics-addr", ":9100", "The address the metric endpoint binds to")
 	flag.StringVar(&kubeconfig, "kubeconfig", "", "Path to kubeconfig file (not needed in cluster)")
 	flag.StringVar(&nodeName, "node-name", "", "Name of the node this agent is running on (defaults to environment variable NODE_NAME)")
-	flag.BoolVar(&annotateOnly, "annotate-only", false, "Only annotate CPU info and exit")
 	klog.InitFlags(nil)
 	flag.Parse()
 
@@ -444,8 +442,7 @@ func main() {
 	// Log startup
 	klog.InfoS("Starting CPU information exporter",
 		"node", nodeName,
-		"metricsAddr", metricsAddr,
-		"annotateOnly", annotateOnly)
+		"metricsAddr", metricsAddr)
 
 	// Create Kubernetes client
 	var config *rest.Config
@@ -474,15 +471,9 @@ func main() {
 	}
 
 	// Annotate the node with CPU model info
-	if err := annotateCPUModel(clientset, nodeName); err != nil {
+	if err := updateNodeCPUModelLabel(clientset, nodeName); err != nil {
 		klog.ErrorS(err, "Failed to annotate node with CPU model information")
 		// Continue running even if annotation fails
-	}
-
-	// If annotate-only mode, exit after annotation
-	if annotateOnly {
-		klog.InfoS("Annotation completed, exiting (annotate-only mode)")
-		os.Exit(0)
 	}
 
 	// Start collecting metrics

--- a/pkg/computegardener/common/constants.go
+++ b/pkg/computegardener/common/constants.go
@@ -2,7 +2,7 @@ package common
 
 // Constants for annotation keys used throughout the compute-gardener-scheduler project
 const (
-	// Base annotation prefix for all compute-gardener annotations
+	// Base prefix for all compute-gardener annotations
 	AnnotationBase = "compute-gardener-scheduler.kubernetes.io"
 
 	// ----------------------------------------
@@ -57,17 +57,27 @@ const (
 	// Node annotations
 	// ----------------------------------------
 
-	// Hardware annotations - CPU
-	AnnotationCPUModel                   = AnnotationBase + "/cpu-model"
-	AnnotationCPUBaseFrequency           = AnnotationBase + "/cpu-base-frequency"            // Base/nominal CPU frequency in GHz
-	AnnotationCPUMinFrequency            = AnnotationBase + "/cpu-min-frequency"             // Minimum CPU frequency in GHz
-	AnnotationCPUMaxFrequency            = AnnotationBase + "/cpu-max-frequency"             // Maximum CPU frequency in GHz
-	AnnotationCPUDynamicFrequencyEnabled = AnnotationBase + "/cpu-dynamic-frequency-enabled" // Whether to dynamically check CPU frequency
+	// Node Feature Discovery (NFD) labels for hardware information
+	// Base prefix for all NFD labels
+	NFDLabelBase = "feature.node.kubernetes.io"
 
-	// Hardware annotations - GPU
-	AnnotationGPUModel      = AnnotationBase + "/gpu-model"
-	AnnotationGPUCount      = AnnotationBase + "/gpu-count"
-	AnnotationGPUTotalPower = AnnotationBase + "/gpu-total-power"
+	// CPU labels - from standard NFD discovery
+	NFDLabelCPUModel         = NFDLabelBase + "/cpu-model.name"
+	NFDLabelCPUBaseFrequency = NFDLabelBase + "/cpu-hardware_limits.base_frequency_khz" // Note: in kHz, need to convert
+	NFDLabelCPUMinFrequency  = NFDLabelBase + "/cpu-hardware_limits.min_frequency_khz"  // Note: in kHz, need to convert
+	NFDLabelCPUMaxFrequency  = NFDLabelBase + "/cpu-hardware_limits.max_frequency_khz"  // Note: in kHz, need to convert
+
+	// Generic NFD labels for PCIe devices (may be used for non-NVIDIA GPUs)
+	NFDLabelPCIVendorPrefix = NFDLabelBase + "/pci-" // Vendor-specific prefixes follow
+
+	NvidiaLabelBase = "nvidia.com/gpu"
+
+	// GPU labels - from standard NFD discovery or NVIDIA GPU operator
+	NvidiaLabelGPUCount   = NvidiaLabelBase + ".count"
+	NvidiaLabelGPUProduct = NFDLabelBase + ".product" // For NVIDIA GPU model
+
+	// CPU frequency dynamic check enabled
+	AnnotationCPUDynamicFrequencyEnabled = AnnotationBase + "/cpu-dynamic-frequency-enabled" // Whether to dynamically check CPU frequency
 )
 
 // Energy budget actions

--- a/pkg/computegardener/metrics/hardware_profiler_test.go
+++ b/pkg/computegardener/metrics/hardware_profiler_test.go
@@ -6,6 +6,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/elevated-systems/compute-gardener-scheduler/pkg/computegardener/common"
 	"github.com/elevated-systems/compute-gardener-scheduler/pkg/computegardener/config"
 )
 
@@ -114,9 +115,9 @@ func TestHardwareProfilerWithOnPrem(t *testing.T) {
 	onPremNode := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "on-prem-node",
-			Annotations: map[string]string{
-				"compute-gardener-scheduler.kubernetes.io/cpu-model": "Intel(R) Core(TM) i5-6500 CPU @ 3.20GHz",
-				"compute-gardener-scheduler.kubernetes.io/gpu-model": "NVIDIA GeForce GTX 1660",
+			Labels: map[string]string{
+				common.NFDLabelCPUModel:      "Intel(R) Core(TM) i5-6500 CPU @ 3.20GHz",
+				common.NvidiaLabelGPUProduct: "NVIDIA GeForce GTX 1660",
 			},
 		},
 	}

--- a/pkg/computegardener/scheduler_metrics_collection.go
+++ b/pkg/computegardener/scheduler_metrics_collection.go
@@ -423,7 +423,7 @@ func (cs *ComputeGardenerScheduler) calculatePodPower(nodeName string, cpu, memo
 
 		// Log CPU model annotation for diagnostics
 		cpuModel := "missing"
-		if val, ok := node.Annotations[common.AnnotationCPUModel]; ok {
+		if val, ok := node.Labels[common.NFDLabelCPUModel]; ok {
 			cpuModel = val
 		}
 
@@ -627,9 +627,9 @@ func (cs *ComputeGardenerScheduler) getNodeCPUModelInfo(nodeName string) (string
 		return "", 0.0, "quadratic"
 	}
 
-	// Try to get CPU model from node annotations
+	// Try to get CPU model from node label
 	cpuModel := ""
-	if model, ok := node.Annotations[common.AnnotationCPUModel]; ok {
+	if model, ok := node.Labels[common.NFDLabelCPUModel]; ok {
 		cpuModel = model
 		klog.V(2).InfoS("Found CPU model from node annotation", "node", nodeName, "model", cpuModel)
 	} else {
@@ -641,7 +641,7 @@ func (cs *ComputeGardenerScheduler) getNodeCPUModelInfo(nodeName string) (string
 	powerScaling := "quadratic" // Default power scaling model
 
 	// Get base frequency from annotation if available
-	if freqStr, ok := node.Annotations[common.AnnotationCPUBaseFrequency]; ok {
+	if freqStr, ok := node.Labels[common.NFDLabelCPUBaseFrequency]; ok {
 		if freq, err := strconv.ParseFloat(freqStr, 64); err == nil {
 			baseFreq = freq
 			klog.V(2).InfoS("Found base frequency from annotation", "node", nodeName, "freq", baseFreq)

--- a/pkg/computegardener/scheduler_test.go
+++ b/pkg/computegardener/scheduler_test.go
@@ -842,18 +842,18 @@ func TestFilterWithHardwareProfile(t *testing.T) {
 	node1 := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-node-1",
-			Annotations: map[string]string{
-				common.AnnotationCPUModel: "Intel",
-				common.AnnotationGPUModel: "NVIDIA A100",
+			Labels: map[string]string{
+				common.NFDLabelCPUModel:      "Intel",
+				common.NvidiaLabelGPUProduct: "NVIDIA A100",
 			},
 		},
 	}
 	node2 := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-node-2",
-			Annotations: map[string]string{
-				common.AnnotationCPUModel: "AMD",
-				common.AnnotationGPUModel: "NVIDIA V100",
+			Labels: map[string]string{
+				common.NFDLabelCPUModel:      "AMD",
+				common.NvidiaLabelGPUProduct: "NVIDIA V100",
 			},
 		},
 	}
@@ -1167,7 +1167,7 @@ func TestFilterWithUnknownHardwareProfile(t *testing.T) {
 	node := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "unknown-node",
-			Labels: map[string]string{common.AnnotationCPUModel: "unknown-cpu"},
+			Labels: map[string]string{common.NFDLabelCPUModel: "unknown-cpu"},
 		},
 		Status: v1.NodeStatus{
 			Capacity: v1.ResourceList{
@@ -1241,7 +1241,7 @@ func TestFilterWithMismatchedHardwareInfo(t *testing.T) {
 	node := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "mismatched-node",
-			Labels: map[string]string{common.AnnotationCPUModel: "testCPU"}, // Valid CPU
+			Labels: map[string]string{common.NFDLabelCPUModel: "testCPU"}, // Valid CPU
 		},
 		Status: v1.NodeStatus{
 			Capacity: v1.ResourceList{


### PR DESCRIPTION
#17 shows that standard community NFD labels should be used in-place of any custom annotations. This PR makes those changes.