### PR TITLE
set placeholder value for electricity rate gauge even when TOU not used

### DIFF
--- a/pkg/computegardener/metrics_collection.go
+++ b/pkg/computegardener/metrics_collection.go
@@ -93,6 +93,10 @@ func (cs *ComputeGardenerScheduler) collectPodMetrics(ctx context.Context) {
 			"rate", currentRate,
 			"period", period,
 			"isPeak", isPeak)
+	} else {
+		// Set placeholder value when pricing is not enabled to prevent dashboard "no data" errors
+		metrics.ElectricityRateGauge.WithLabelValues("tou", "off-peak").Set(0)
+		klog.V(2).InfoS("Set electricity rate gauge to 0 (pricing not enabled)")
 	}
 
 	// Get metrics for all pods


### PR DESCRIPTION
Fixes #34 and partially addresses #27 by ensuring the ElectricityRateGauge always has a value, preventing dashboard "no data" errors when TOU cost control is not enabled. Also helps reduce stale data issues by ensuring the gauge is updated during periodic metrics collection cycles.

When pricing is disabled, the gauge now reports 0 with the "off-peak" period label, allowing dashboards to display the metric gracefully.