### PR TITLE
fix: resolve race condition between dryrun webhook and apiserver

### DIFF
--- a/cmd/dryrun/main.go
+++ b/cmd/dryrun/main.go
@@ -19,18 +19,19 @@ import (
 
 func main() {
 	var (
-		webhookPort     int
-		metricsPort     int
-		mode            string
-		filterMode      string
-		watchNamespaces stringSlice
-		carbonEnabled   bool
-		carbonRegion    string
-		carbonThreshold float64
-		carbonAPIKey    string
-		pricingEnabled  bool
-		tlsCertPath     string
-		tlsKeyPath      string
+		webhookPort        int
+		metricsPort        int
+		mode               string
+		filterMode         string
+		watchNamespaces    stringSlice
+		carbonEnabled      bool
+		carbonRegion       string
+		carbonThreshold    float64
+		carbonAPIKey       string
+		pricingEnabled     bool
+		tlsCertPath        string
+		tlsKeyPath         string
+		webhookTimeoutSeconds int
 	)
 
 	flag.IntVar(&webhookPort, "webhook-port", 8443, "Webhook server port")
@@ -45,6 +46,7 @@ func main() {
 	flag.BoolVar(&pricingEnabled, "pricing-enabled", false, "Enable price-aware evaluation")
 	flag.StringVar(&tlsCertPath, "tls-cert", "/etc/webhook/certs/tls.crt", "Path to TLS certificate")
 	flag.StringVar(&tlsKeyPath, "tls-key", "/etc/webhook/certs/tls.key", "Path to TLS key")
+	flag.IntVar(&webhookTimeoutSeconds, "webhook-timeout", 10, "Admission webhook timeout in seconds; the internal evaluation deadline runs 1s under this")
 
 	klog.InitFlags(nil)
 	flag.Parse()
@@ -95,9 +97,10 @@ func main() {
 
 	// Create dry-run configuration
 	dryRunConfig := &dryrun.Config{
-		Mode:            mode,
-		FilterMode:      filterMode,
-		WatchNamespaces: watchNamespaces,
+		Mode:               mode,
+		FilterMode:         filterMode,
+		WatchNamespaces:    watchNamespaces,
+		WebhookTimeoutSeconds: webhookTimeoutSeconds,
 		Carbon: dryrun.CarbonConfig{
 			Enabled:   carbonEnabled,
 			Region:    carbonRegion,

--- a/manifests/install/charts/compute-gardener-scheduler/templates/dryrun-deployment.yaml
+++ b/manifests/install/charts/compute-gardener-scheduler/templates/dryrun-deployment.yaml
@@ -42,6 +42,7 @@ spec:
         - --watch-namespace={{ . }}
         {{- end }}
         {{- end }}
+        - --webhook-timeout={{ .Values.dryRun.webhook.timeoutSeconds | default 10 }}
         - --tls-cert=/tmp/k8s-webhook-server/serving-certs/tls.crt
         - --tls-key=/tmp/k8s-webhook-server/serving-certs/tls.key
         - --v={{ .Values.dryRun.logLevel | default 3 }}

--- a/manifests/install/charts/compute-gardener-scheduler/templates/dryrun-webhook.yaml
+++ b/manifests/install/charts/compute-gardener-scheduler/templates/dryrun-webhook.yaml
@@ -34,7 +34,7 @@ webhooks:
   # If it fails, allow pod creation to proceed
   failurePolicy: Ignore
   {{- end }}
-  timeoutSeconds: 5
+  timeoutSeconds: {{ .Values.dryRun.webhook.timeoutSeconds | default 10 }}
   {{- if and (eq .Values.dryRun.filterMode "namespace") .Values.dryRun.watchNamespaces }}
   namespaceSelector:
     matchExpressions:

--- a/pkg/computegardener/common/constants.go
+++ b/pkg/computegardener/common/constants.go
@@ -24,14 +24,14 @@ const (
 	AnnotationEnergyBudgetExceededBy = AnnotationBase + "/energy-budget-exceeded-by"
 
 	// Carbon and cost tracking annotations
-	AnnotationInitialCarbonIntensity  = AnnotationBase + "/initial-carbon-intensity"
-	AnnotationInitialElectricityRate  = AnnotationBase + "/initial-electricity-rate"
-	AnnotationInitialTimestamp        = AnnotationBase + "/initial-timestamp"           // RFC3339 timestamp when pod was first delayed (DEPRECATED: use carbon or price specific)
-	AnnotationCarbonDelayTimestamp    = AnnotationBase + "/carbon-delay-timestamp"      // RFC3339 timestamp when pod was first delayed by carbon
-	AnnotationPriceDelayTimestamp     = AnnotationBase + "/price-delay-timestamp"       // RFC3339 timestamp when pod was first delayed by price
-	AnnotationBindTimestamp           = AnnotationBase + "/bind-timestamp"              // RFC3339 timestamp when pod bound to node
-	AnnotationBindCarbonIntensity     = AnnotationBase + "/bind-time-carbon-intensity"  // Carbon intensity when pod bound
-	AnnotationBindElectricityRate     = AnnotationBase + "/bind-time-electricity-rate"  // Electricity rate when pod bound
+	AnnotationInitialCarbonIntensity = AnnotationBase + "/initial-carbon-intensity"
+	AnnotationInitialElectricityRate = AnnotationBase + "/initial-electricity-rate"
+	AnnotationInitialTimestamp       = AnnotationBase + "/initial-timestamp"          // RFC3339 timestamp when pod was first delayed (DEPRECATED: use carbon or price specific)
+	AnnotationCarbonDelayTimestamp   = AnnotationBase + "/carbon-delay-timestamp"     // RFC3339 timestamp when pod was first delayed by carbon
+	AnnotationPriceDelayTimestamp    = AnnotationBase + "/price-delay-timestamp"      // RFC3339 timestamp when pod was first delayed by price
+	AnnotationBindTimestamp          = AnnotationBase + "/bind-timestamp"             // RFC3339 timestamp when pod bound to node
+	AnnotationBindCarbonIntensity    = AnnotationBase + "/bind-time-carbon-intensity" // Carbon intensity when pod bound
+	AnnotationBindElectricityRate    = AnnotationBase + "/bind-time-electricity-rate" // Electricity rate when pod bound
 
 	// Hardware efficiency annotations
 	AnnotationMaxPowerWatts   = AnnotationBase + "/max-power-watts"

--- a/pkg/computegardener/dryrun/store_test.go
+++ b/pkg/computegardener/dryrun/store_test.go
@@ -14,17 +14,17 @@ func TestPodEvaluationStore_RecordAndGetStart(t *testing.T) {
 	startTime := now.Add(-5 * time.Hour)
 
 	startData := &eval.PodStartData{
-		UID:              "test-uid",
-		Namespace:        "default",
-		StartTime:        startTime,
-		EstimatedPowerW:  100.0,
+		UID:               "test-uid",
+		Namespace:         "default",
+		StartTime:         startTime,
+		EstimatedPowerW:   100.0,
 		EstimatedRuntimeH: 4.0,
-		WouldHaveDelayed: true,
-		DelayType:        "carbon",
-		InitialCarbon:    1.5,
-		CarbonThreshold:  1.0,
-		InitialPrice:     0.06,
-		PriceThreshold:   0.05,
+		WouldHaveDelayed:  true,
+		DelayType:         "carbon",
+		InitialCarbon:     1.5,
+		CarbonThreshold:   1.0,
+		InitialPrice:      0.06,
+		PriceThreshold:    0.05,
 	}
 
 	store.RecordStart("test-uid", startData)

--- a/pkg/computegardener/dryrun/types.go
+++ b/pkg/computegardener/dryrun/types.go
@@ -19,11 +19,12 @@ const (
 
 // Config holds configuration for the dry-run system
 type Config struct {
-	Mode            string   // "metrics" or "annotate"
-	FilterMode      string   // "schedulerName" (default) or "namespace"
-	WatchNamespaces []string // Namespaces to evaluate (only used in namespace filter mode)
-	Carbon          CarbonConfig
-	Pricing         PricingConfig
+	Mode               string   // "metrics" or "annotate"
+	FilterMode         string   // "schedulerName" (default) or "namespace"
+	WatchNamespaces    []string // Namespaces to evaluate (only used in namespace filter mode)
+	WebhookTimeoutSeconds int // Must match MutatingWebhookConfiguration timeoutSeconds; eval runs 1s under this
+	Carbon             CarbonConfig
+	Pricing            PricingConfig
 }
 
 // CarbonConfig holds carbon-aware evaluation settings

--- a/pkg/computegardener/dryrun/webhook.go
+++ b/pkg/computegardener/dryrun/webhook.go
@@ -139,8 +139,10 @@ func (w *Webhook) handleAdmission(req *admissionv1.AdmissionRequest) *admissionv
 		return w.buildResponse(patches)
 	}
 
-	// Evaluate pod constraints
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	// Evaluate pod constraints 1s under the Kubernetes webhook timeout so we
+	// always respond before the apiserver deadline discards our response.
+	evalTimeout := time.Duration(w.config.WebhookTimeoutSeconds-1) * time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), evalTimeout)
 	defer cancel()
 
 	result, err := w.evaluator.EvaluateAll(ctx, &pod, time.Now())

--- a/pkg/computegardener/eval/evaluator_test.go
+++ b/pkg/computegardener/eval/evaluator_test.go
@@ -77,7 +77,7 @@ func TestDetermineWorkloadType(t *testing.T) {
 		{
 			name: "explicit label overrides everything",
 			pod: &v1.Pod{ObjectMeta: metav1.ObjectMeta{
-				Labels: map[string]string{common.LabelWorkloadType: "batch"},
+				Labels:          map[string]string{common.LabelWorkloadType: "batch"},
 				OwnerReferences: []metav1.OwnerReference{{Kind: "Deployment"}},
 			}},
 			expected: "batch",
@@ -224,11 +224,11 @@ func TestEvaluateCarbonConstraints_ThresholdLogic(t *testing.T) {
 	ctx := context.Background()
 
 	tests := []struct {
-		name            string
+		name             string
 		currentIntensity float64
 		globalThreshold  float64
 		podAnnotation    string
-		wantDelay       bool
+		wantDelay        bool
 	}{
 		{
 			name:             "below global threshold → no delay",
@@ -330,11 +330,11 @@ func TestEvaluatePriceConstraints_PodAnnotationThreshold(t *testing.T) {
 	cfg := priceOnlyConfig()
 
 	tests := []struct {
-		name          string
-		rate          float64
-		isPeak        bool
-		annotation    string
-		wantDelay     bool
+		name       string
+		rate       float64
+		isPeak     bool
+		annotation string
+		wantDelay  bool
 	}{
 		{
 			name:       "rate exceeds annotation threshold → delay even off-peak",

--- a/pkg/computegardener/pod_completion_test.go
+++ b/pkg/computegardener/pod_completion_test.go
@@ -234,10 +234,10 @@ var savingsTestCases = []MetricsTestCase{
 			Completed: false,
 		},
 		PodAnnotations: map[string]string{
-			common.AnnotationInitialCarbonIntensity: "200",  // Initial (when scheduler first heard)
-			common.AnnotationInitialElectricityRate: "0.18", // Initial (when scheduler first heard)
-			common.AnnotationBindCarbonIntensity:    "150",  // Bind-time (first metrics record)
-			common.AnnotationBindElectricityRate:    "0.12", // Bind-time (first metrics record)
+			common.AnnotationInitialCarbonIntensity: "200",                                                  // Initial (when scheduler first heard)
+			common.AnnotationInitialElectricityRate: "0.18",                                                 // Initial (when scheduler first heard)
+			common.AnnotationBindCarbonIntensity:    "150",                                                  // Bind-time (first metrics record)
+			common.AnnotationBindElectricityRate:    "0.12",                                                 // Bind-time (first metrics record)
 			common.AnnotationInitialTimestamp:       time.Now().Add(-15 * time.Minute).Format(time.RFC3339), // When first delayed
 		},
 		WasCarbonDelayed: true, // Pod was delayed by carbon constraints
@@ -274,10 +274,10 @@ var savingsTestCases = []MetricsTestCase{
 			Completed: false,
 		},
 		PodAnnotations: map[string]string{
-			common.AnnotationInitialCarbonIntensity: "150",  // Initial (when scheduler first heard)
-			common.AnnotationInitialElectricityRate: "0.12", // Initial (when scheduler first heard)
-			common.AnnotationBindCarbonIntensity:    "200",  // Bind-time (first metrics record)
-			common.AnnotationBindElectricityRate:    "0.18", // Bind-time (first metrics record)
+			common.AnnotationInitialCarbonIntensity: "150",                                                  // Initial (when scheduler first heard)
+			common.AnnotationInitialElectricityRate: "0.12",                                                 // Initial (when scheduler first heard)
+			common.AnnotationBindCarbonIntensity:    "200",                                                  // Bind-time (first metrics record)
+			common.AnnotationBindElectricityRate:    "0.18",                                                 // Bind-time (first metrics record)
 			common.AnnotationInitialTimestamp:       time.Now().Add(-15 * time.Minute).Format(time.RFC3339), // When first delayed
 		},
 		WasCarbonDelayed: true, // Pod was delayed by carbon constraints
@@ -344,7 +344,7 @@ var savingsTestCases = []MetricsTestCase{
 			Completed: false,
 		},
 		PodAnnotations: map[string]string{
-			common.AnnotationInitialCarbonIntensity: "200", // Initial when first seen
+			common.AnnotationInitialCarbonIntensity: "200",  // Initial when first seen
 			common.AnnotationInitialElectricityRate: "0.10", // Initial when first seen
 			common.AnnotationBindCarbonIntensity:    "120",  // Bind-time intensity
 			common.AnnotationBindElectricityRate:    "0.10", // Bind-time rate


### PR DESCRIPTION
Resolve #51 race condition between dryrun webhook and apiserver admission timeout

The internal evaluation timeout in the dryrun webhook was hardcoded to 5s — identical to the MutatingWebhookConfiguration timeoutSeconds. When the Electricity Maps API responded slowly, the apiserver's deadline expired first and discarded the webhook response, admitting pods unmutated with no dry-run annotations. These pods then sat permanently pending with schedulerName: compute-gardener-scheduler and no scheduler to claim them.

Fix: introduce a single dryRun.webhook.timeoutSeconds value (default 10s) as the source of truth for both the MutatingWebhookConfiguration timeout and the --webhook-timeout flag passed to the binary. The webhook enforces evalTimeout = webhookTimeout - 1s in code, guaranteeing the apiserver always receives a response before its deadline.