### PR TITLE
scheduler: stop flagging healthy carbon cache staleness as an error (#50)

### DIFF
--- a/pkg/computegardener/cache/cache.go
+++ b/pkg/computegardener/cache/cache.go
@@ -190,6 +190,19 @@ func (c *Cache) Close() {
 	close(c.stopCh)
 }
 
+// TestBackdate ages an existing cache entry by the given duration. This is a
+// test-only helper that lets tests backdate an entry's internal timestamp so
+// that OldestEntryAge reports a deterministic age. It is a no-op if the region
+// is not present.
+func (c *Cache) TestBackdate(region string, age time.Duration) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	if entry, exists := c.data[region]; exists {
+		entry.timestamp = time.Now().Add(-age)
+	}
+}
+
 // Clear removes all entries from the cache
 func (c *Cache) Clear() {
 	c.mutex.Lock()
@@ -216,4 +229,30 @@ func (c *Cache) GetRegions() []string {
 		regions = append(regions, region)
 	}
 	return regions
+}
+
+// OldestEntryAge returns the age of the oldest entry currently in the cache,
+// along with the region it belongs to. It returns (0, "", false) when the
+// cache is empty. Callers use this to tell a cache that is merely a few
+// seconds stale (normal between refreshes) apart from one that has gone
+// fully stale (refresh worker failing).
+func (c *Cache) OldestEntryAge() (time.Duration, string, bool) {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+
+	if len(c.data) == 0 {
+		return 0, "", false
+	}
+
+	now := time.Now()
+	var oldestAge time.Duration
+	oldestRegion := ""
+	for region, entry := range c.data {
+		age := now.Sub(entry.timestamp)
+		if oldestRegion == "" || age > oldestAge {
+			oldestAge = age
+			oldestRegion = region
+		}
+	}
+	return oldestAge, oldestRegion, true
 }

--- a/pkg/computegardener/cache/cache_test.go
+++ b/pkg/computegardener/cache/cache_test.go
@@ -266,3 +266,48 @@ func TestEnsurePositiveDuration(t *testing.T) {
 		t.Errorf("Expected 1m, got %v for negative duration", result)
 	}
 }
+
+func TestOldestEntryAgeEmpty(t *testing.T) {
+	c := New(time.Minute, time.Hour)
+	defer c.Close()
+
+	_, _, ok := c.OldestEntryAge()
+	if ok {
+		t.Error("OldestEntryAge() reported data present on an empty cache")
+	}
+}
+
+func TestOldestEntryAge(t *testing.T) {
+	c := New(time.Minute, time.Hour)
+	defer c.Close()
+
+	// One fresh entry and one backdated entry. OldestEntryAge should report
+	// the backdated one and an age close to how far back it was pushed.
+	fresh := time.Now()
+	old := time.Now().Add(-3 * time.Minute)
+
+	c.Set("fresh-region", &api.ElectricityData{CarbonIntensity: 100, Timestamp: fresh})
+	c.Set("stale-region", &api.ElectricityData{CarbonIntensity: 200, Timestamp: old})
+
+	// Backdate the stale entry's internal timestamp (Set records its own wall
+	// clock, so we override to make the age deterministic).
+	c.mutex.Lock()
+	if e, exists := c.data["stale-region"]; exists {
+		e.timestamp = old
+	}
+	if e, exists := c.data["fresh-region"]; exists {
+		e.timestamp = fresh
+	}
+	c.mutex.Unlock()
+
+	age, region, ok := c.OldestEntryAge()
+	if !ok {
+		t.Fatal("OldestEntryAge() reported no data on a populated cache")
+	}
+	if region != "stale-region" {
+		t.Errorf("Expected oldest region 'stale-region', got %q", region)
+	}
+	if age < 2*time.Minute || age > 4*time.Minute {
+		t.Errorf("Expected oldest age ~3m, got %v", age)
+	}
+}

--- a/pkg/computegardener/cache_health_test.go
+++ b/pkg/computegardener/cache_health_test.go
@@ -1,0 +1,235 @@
+package computegardener
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/elevated-systems/compute-gardener-scheduler/pkg/computegardener/api"
+	cachepkg "github.com/elevated-systems/compute-gardener-scheduler/pkg/computegardener/cache"
+	"github.com/elevated-systems/compute-gardener-scheduler/pkg/computegardener/config"
+	testingmocks "github.com/elevated-systems/compute-gardener-scheduler/pkg/computegardener/testing"
+
+	testingclock "k8s.io/utils/clock/testing"
+)
+
+// newCacheHealthTestScheduler builds a scheduler wired up for exercising the
+// carbon cache health logic: carbon enabled with a healthy (reachable) mock
+// data source, pricing disabled, and a real cache whose contents the test
+// controls.
+func newCacheHealthTestScheduler(t *testing.T, cache *cachepkg.Cache, failures int) *ComputeGardenerScheduler {
+	t.Helper()
+
+	baseTime := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	cfg := &config.Config{
+		Cache: config.APICacheConfig{
+			Timeout:     time.Second,
+			MaxRetries:  3,
+			RetryDelay:  time.Second,
+			RateLimit:   10,
+			CacheTTL:    time.Minute,
+			MaxCacheAge: time.Hour,
+		},
+		Carbon: config.CarbonConfig{
+			Enabled:            true,
+			Provider:           "electricity-maps-api",
+			IntensityThreshold: 200,
+			APIConfig: config.ElectricityMapsAPIConfig{
+				APIKey: "test-key",
+				Region: "test-region",
+				URL:    "http://mock-url/",
+			},
+		},
+		Pricing: config.PriceConfig{
+			Enabled: false,
+		},
+	}
+
+	cs := &ComputeGardenerScheduler{
+		handle:            &mockHandle{},
+		config:            cfg,
+		cache:             cache,
+		priceImpl:         testingmocks.NewMockPricing(0.1),
+		carbonImpl:        testingmocks.NewMockCarbon(100),
+		clock:             testingclock.NewFakeClock(baseTime),
+		startTime:         baseTime.Add(-10 * time.Minute),
+		carbonDelayedPods: make(map[string]bool),
+		priceDelayedPods:  make(map[string]bool),
+	}
+	cs.carbonRefreshFailures = failures
+	return cs
+}
+
+// newCacheHealthCache creates a cache populated with a single entry for the
+// test region, backdated by the given age (0 leaves it fresh).
+func newCacheHealthCache(t *testing.T, ttl, age time.Duration) *cachepkg.Cache {
+	t.Helper()
+	cache := cachepkg.New(ttl, time.Hour)
+	t.Cleanup(cache.Close)
+	cache.Set("test-region", &api.ElectricityData{CarbonIntensity: 100})
+	if age > 0 {
+		cache.TestBackdate("test-region", age)
+	}
+	return cache
+}
+
+func TestCheckCarbonCacheHealth(t *testing.T) {
+	// checkCarbonCacheHealth is a pure function of cache state and the
+	// refresh-worker failure counter; it does NOT gate on the carbon enabled
+	// flag (its caller, healthCheck, does). These cases cover the distinction
+	// introduced for issue #50: an empty or merely-stale cache is NOT an error
+	// unless the refresh worker is demonstrably failing.
+	tests := []struct {
+		name        string
+		ttl         time.Duration
+		cacheAge    time.Duration // age of the single cached entry; emptyCache => no entry
+		emptyCache  bool
+		failures    int
+		expectError bool
+		errContains string
+	}{
+		{
+			name:       "empty cache, no failures is normal at startup",
+			ttl:        time.Minute,
+			emptyCache: true,
+			failures:   0,
+		},
+		{
+			name:        "empty cache with repeated refresh failures is an error",
+			ttl:         time.Minute,
+			emptyCache:  true,
+			failures:    3,
+			expectError: true,
+			errContains: "not reaching the cache",
+		},
+		{
+			name:     "fresh data, healthy refresh",
+			ttl:      time.Minute,
+			cacheAge: 10 * time.Second,
+			failures: 0,
+		},
+		{
+			// Past TTL but the refresh worker has not been failing: transient
+			// staleness, must NOT be an error (the on-demand fetch covers it).
+			// This is the core of issue #50.
+			name:     "stale data but healthy refresh is not an error",
+			ttl:      time.Minute,
+			cacheAge: 3 * time.Minute,
+			failures: 0,
+		},
+		{
+			name:        "stale data and repeated refresh failures is an error",
+			ttl:         time.Minute,
+			cacheAge:    4 * time.Minute,
+			failures:    4,
+			expectError: true,
+			errContains: "may be unreachable",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var cache *cachepkg.Cache
+			if tt.emptyCache {
+				cache = cachepkg.New(tt.ttl, time.Hour)
+				t.Cleanup(cache.Close)
+			} else {
+				cache = newCacheHealthCache(t, tt.ttl, tt.cacheAge)
+			}
+
+			cs := newCacheHealthTestScheduler(t, cache, tt.failures)
+
+			err := cs.checkCarbonCacheHealth()
+			if (err != nil) != tt.expectError {
+				t.Fatalf("checkCarbonCacheHealth() error = %v, expectError %v", err, tt.expectError)
+			}
+			if tt.expectError && tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+				t.Fatalf("error %q does not contain %q", err.Error(), tt.errContains)
+			}
+		})
+	}
+}
+
+// TestHealthCheckCarbonCacheGating verifies that healthCheck skips the carbon
+// cache inspection entirely when carbon is disabled, even if the cache state
+// would otherwise be an error. (When carbon is enabled, healthCheck delegates
+// to checkCarbonCacheHealth, which is covered in TestCheckCarbonCacheHealth.)
+func TestHealthCheckCarbonCacheGating(t *testing.T) {
+	// A cache state that checkCarbonCacheHealth would flag as an error.
+	cache := newCacheHealthCache(t, time.Minute, 10*time.Minute)
+	cs := newCacheHealthTestScheduler(t, cache, 5)
+
+	cs.config.Carbon.Enabled = false
+	if err := cs.healthCheck(context.Background()); err != nil {
+		t.Fatalf("healthCheck() with carbon disabled should ignore the carbon cache, got error: %v", err)
+	}
+
+	// Sanity check: the same scheduler DOES surface the cache problem once
+	// carbon is re-enabled, confirming the gating (not the cache state) is
+	// what suppressed it.
+	cs.config.Carbon.Enabled = true
+	if err := cs.healthCheck(context.Background()); err == nil {
+		t.Fatal("healthCheck() with carbon enabled should surface the stale-cache error")
+	}
+}
+
+func TestCarbonCacheRefreshOutcomeTracking(t *testing.T) {
+	cs := newCacheHealthTestScheduler(t, cachepkg.New(time.Minute, time.Hour), 0)
+	t.Cleanup(cs.cache.Close)
+
+	cs.recordCarbonRefreshOutcome(false)
+	cs.recordCarbonRefreshOutcome(false)
+	cs.recordCarbonRefreshOutcome(false)
+	cs.refreshMu.Lock()
+	failures := cs.carbonRefreshFailures
+	cs.refreshMu.Unlock()
+	if failures != 3 {
+		t.Fatalf("Expected 3 consecutive failures, got %d", failures)
+	}
+
+	// A single success resets the streak.
+	cs.recordCarbonRefreshOutcome(true)
+	cs.refreshMu.Lock()
+	failures = cs.carbonRefreshFailures
+	cs.refreshMu.Unlock()
+	if failures != 0 {
+		t.Fatalf("Expected failure streak reset to 0 after success, got %d", failures)
+	}
+
+	// Failure streaks build up again after a recovery.
+	cs.recordCarbonRefreshOutcome(false)
+	cs.refreshMu.Lock()
+	failures = cs.carbonRefreshFailures
+	cs.refreshMu.Unlock()
+	if failures != 1 {
+		t.Fatalf("Expected 1 failure after recovery, got %d", failures)
+	}
+}
+
+// TestRefreshCarbonCacheRecordsOutcomes drives refreshCarbonCache end-to-end
+// with a mock data source that succeeds then fails, verifying the outcome is
+// recorded.
+func TestRefreshCarbonCacheRecordsOutcomes(t *testing.T) {
+	cs := newCacheHealthTestScheduler(t, cachepkg.New(time.Minute, time.Hour), 0)
+	t.Cleanup(cs.cache.Close)
+
+	// Success path.
+	cs.refreshCarbonCache(context.Background(), []string{"test-region"})
+	cs.refreshMu.Lock()
+	failures := cs.carbonRefreshFailures
+	cs.refreshMu.Unlock()
+	if failures != 0 {
+		t.Fatalf("Expected 0 failures after a successful refresh, got %d", failures)
+	}
+
+	// Now make the data source fail and refresh again.
+	cs.carbonImpl = testingmocks.NewMockCarbonWithError()
+	cs.refreshCarbonCache(context.Background(), []string{"test-region"})
+	cs.refreshMu.Lock()
+	failures = cs.carbonRefreshFailures
+	cs.refreshMu.Unlock()
+	if failures != 1 {
+		t.Fatalf("Expected 1 failure after a failed refresh, got %d", failures)
+	}
+}

--- a/pkg/computegardener/scheduler.go
+++ b/pkg/computegardener/scheduler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"sync"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -68,6 +69,14 @@ type ComputeGardenerScheduler struct {
 	// Delay tracking - track which pods were delayed and why (for metrics deduplication and savings calculation)
 	carbonDelayedPods map[string]bool // Pods delayed by carbon constraints
 	priceDelayedPods  map[string]bool // Pods delayed by price constraints
+
+	// Carbon cache refresh bookkeeping. Used by the health check to distinguish a
+	// transient blip (refresh worker is healthy and the cache is merely a few
+	// seconds stale between refreshes) from a stuck cache (refreshes have failed
+	// repeatedly, so on-demand fetches are likely failing too). Guarded by
+	// refreshMu.
+	refreshMu             sync.Mutex
+	carbonRefreshFailures int
 }
 
 var (
@@ -1065,34 +1074,15 @@ func (cs *ComputeGardenerScheduler) healthCheckWorker(ctx context.Context) {
 }
 
 func (cs *ComputeGardenerScheduler) healthCheck(ctx context.Context) error {
-	// Check cache health
-	regions := cs.cache.GetRegions()
-
-	// Evaluate cache state
-	emptyCache := len(regions) == 0
-	hasFreshData := false
-
-	if !emptyCache {
-		// Check if any region has fresh data
-		for _, region := range regions {
-			if _, fresh := cs.cache.Get(region); fresh {
-				hasFreshData = true
-				break
-			}
+	if cs.config.Carbon.Enabled {
+		if err := cs.checkCarbonCacheHealth(); err != nil {
+			return err
 		}
-	}
-
-	// Only enforce cache health checks if carbon is enabled and cache should be initialized
-	// An empty cache is allowed and normal during initial startup or when carbon features aren't being used
-	if cs.config.Carbon.Enabled && !emptyCache && !hasFreshData {
-		// If we have regions but no fresh data, that's a problem
-		return fmt.Errorf("cache health check failed: no fresh data available")
 	}
 
 	// If carbon awareness enabled, verify API health
 	if cs.config.Carbon.Enabled && cs.carbonImpl != nil {
-		_, err := cs.carbonImpl.GetCurrentIntensity(ctx)
-		if err != nil {
+		if _, err := cs.carbonImpl.GetCurrentIntensity(ctx); err != nil {
 			return fmt.Errorf("carbon API health check failed: %v", err)
 		}
 	}
@@ -1108,6 +1098,91 @@ func (cs *ComputeGardenerScheduler) healthCheck(ctx context.Context) error {
 	return nil
 }
 
+// checkCarbonCacheHealth inspects the carbon intensity cache and returns an
+// error only when the cache is in a genuinely unhealthy state. It deliberately
+// keeps three situations distinct (see issue #50, where the previous version
+// logged "no fresh data available" as an error on every health-check tick on
+// EKS even though scheduling itself was working fine):
+//
+//  1. Empty cache: no entries at all. Normal at startup (the refresh worker
+//     performs its first fetch asynchronously) or when carbon data has simply
+//     never been requested. Not an error by itself - the API reachability is
+//     verified separately, and a fresh fetch happens on demand. It becomes an
+//     error only if the refresh worker is demonstrably failing.
+//
+//  2. Transient staleness: the cache has data but it is past its TTL because
+//     the periodic refresh has not yet run. The refresh worker refreshes at
+//     ~1/3 of the TTL, so a little staleness is expected. As long as the
+//     refresh worker is not failing we only log at info level, because a
+//     scheduling request will transparently trigger a fresh API fetch.
+//
+//  3. Stuck cache: the data is fully stale (older than 2x the TTL) AND the
+//     refresh worker has failed repeatedly. This means on-demand fetches are
+//     likely failing too (e.g. no network egress to the EM API), which does
+//     affect scheduling - so this is a real error.
+func (cs *ComputeGardenerScheduler) checkCarbonCacheHealth() error {
+	oldestAge, oldestRegion, hasData := cs.cache.OldestEntryAge()
+	ttl := cs.config.Cache.CacheTTL
+	if ttl <= 0 {
+		ttl = 5 * time.Minute
+	}
+
+	cs.refreshMu.Lock()
+	failures := cs.carbonRefreshFailures
+	cs.refreshMu.Unlock()
+
+	if !hasData {
+		// Situation 1: cache has never been populated. Only a problem if we
+		// have evidence the refresh worker is failing - otherwise it is just
+		// startup (or the first on-demand fetch hasn't happened yet) and the
+		// API reachability check below covers that.
+		if failures > 0 {
+			return fmt.Errorf("carbon cache is empty and the refresh worker has had %d consecutive failure(s): carbon data is not reaching the cache",
+				failures)
+		}
+		klog.V(2).InfoS("Carbon cache is empty (no data written yet); this is normal at startup or before the first fetch")
+		return nil
+	}
+
+	if oldestAge <= 2*ttl {
+		// Situation 2 (normal side): data is reasonably fresh. Nothing to do.
+		return nil
+	}
+
+	// The oldest entry is more than 2x the TTL old.
+	if failures == 0 {
+		// Transient: the cache is stale but the refresh worker has not been
+		// failing, so the next refresh (or any scheduling request, which
+		// triggers an on-demand fetch) will bring it back. Informational only.
+		klog.InfoS("Carbon cache is stale but the refresh worker is healthy; a fresh fetch will occur on the next refresh or scheduling request",
+			"oldestRegion", oldestRegion,
+			"oldestAge", oldestAge.Round(time.Second),
+			"cacheTTL", ttl)
+		return nil
+	}
+
+	// Situation 3: the cache has gone fully stale and the refresh worker has
+	// failed repeatedly, so on-demand fetches are likely failing as well. This
+	// is a real problem for carbon-aware scheduling.
+	return fmt.Errorf("carbon cache has no fresh data: oldest entry (%s) is %s old (ttl %s) after %d consecutive refresh failure(s) - the carbon data source may be unreachable",
+		oldestRegion,
+		oldestAge.Round(time.Second),
+		ttl,
+		failures)
+}
+
+// carbonCacheRefreshInterval returns the interval used by the carbon cache
+// refresh worker, mirroring the clamping applied in carbonCacheRefreshWorker.
+func (cs *ComputeGardenerScheduler) carbonCacheRefreshInterval() time.Duration {
+	refreshInterval := cs.config.Cache.CacheTTL / 3
+	if refreshInterval < 10*time.Second {
+		refreshInterval = 10 * time.Second
+	} else if refreshInterval > 5*time.Minute {
+		refreshInterval = 5 * time.Minute
+	}
+	return refreshInterval
+}
+
 // hasGPURequest checks if a pod is requesting GPU resources
 func hasGPURequest(pod *v1.Pod) bool {
 	for _, container := range pod.Spec.Containers {
@@ -1121,15 +1196,8 @@ func hasGPURequest(pod *v1.Pod) bool {
 // carbonCacheRefreshWorker refreshes the carbon intensity cache at regular intervals
 // to ensure that the cache never becomes stale when scheduling decisions are made
 func (cs *ComputeGardenerScheduler) carbonCacheRefreshWorker(ctx context.Context) {
-	// Calculate refresh interval as 1/3 of the cache TTL to ensure we always have fresh data
-	refreshInterval := cs.config.Cache.CacheTTL / 3
-
-	// Ensure the interval is not too short or too long
-	if refreshInterval < 10*time.Second {
-		refreshInterval = 10 * time.Second // Minimum 10 seconds
-	} else if refreshInterval > 5*time.Minute {
-		refreshInterval = 5 * time.Minute // Maximum 5 minutes
-	}
+	// Refresh at ~1/3 of the cache TTL (clamped) so we always have fresh data.
+	refreshInterval := cs.carbonCacheRefreshInterval()
 
 	klog.InfoS("Starting carbon intensity cache refresh worker",
 		"refreshInterval", refreshInterval.String(),
@@ -1158,6 +1226,7 @@ func (cs *ComputeGardenerScheduler) carbonCacheRefreshWorker(ctx context.Context
 
 // refreshCarbonCache refreshes the carbon intensity data for given regions
 func (cs *ComputeGardenerScheduler) refreshCarbonCache(ctx context.Context, regions []string) {
+	allSucceeded := true
 	for _, region := range regions {
 		// Create a context with timeout for the API request
 		requestCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
@@ -1169,6 +1238,7 @@ func (cs *ComputeGardenerScheduler) refreshCarbonCache(ctx context.Context, regi
 		cancel()
 
 		if err != nil {
+			allSucceeded = false
 			klog.ErrorS(err, "Failed to refresh carbon intensity cache",
 				"region", region)
 		} else {
@@ -1180,5 +1250,33 @@ func (cs *ComputeGardenerScheduler) refreshCarbonCache(ctx context.Context, regi
 			// Update metrics
 			metrics.CarbonIntensityGauge.WithLabelValues(region, intensityData.DataStatus).Set(intensityData.Value)
 		}
+	}
+
+	// Record the outcome so the health check can distinguish a transient blip
+	// (refresh worker is healthy) from a stuck cache (refreshes failing
+	// repeatedly, meaning on-demand fetches are likely failing too).
+	cs.recordCarbonRefreshOutcome(allSucceeded)
+}
+
+// recordCarbonRefreshOutcome updates the consecutive carbon-cache refresh
+// failure counter used by the health check. The counter resets to zero as soon
+// as a refresh succeeds, so it reflects only the current failure streak.
+func (cs *ComputeGardenerScheduler) recordCarbonRefreshOutcome(success bool) {
+	cs.refreshMu.Lock()
+	defer cs.refreshMu.Unlock()
+
+	if success {
+		if cs.carbonRefreshFailures > 0 {
+			klog.V(2).InfoS("Carbon cache refresh recovered",
+				"previousConsecutiveFailures", cs.carbonRefreshFailures)
+		}
+		cs.carbonRefreshFailures = 0
+		return
+	}
+
+	cs.carbonRefreshFailures++
+	if cs.carbonRefreshFailures == 1 {
+		klog.V(1).InfoS("Carbon cache refresh is failing",
+			"consecutiveFailures", cs.carbonRefreshFailures)
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #50 — the scheduler's periodic health check logged `cache health check failed: no fresh data available` as an **error** on every health-check tick on EKS, even though scheduling itself was working fine (the API client transparently refetches on demand whenever a cached entry is past its TTL).

The old check treated *any* past-TTL cached region as a hard failure, so a normal gap between the refresh worker's ticks (it runs at ~1/3 TTL) or a slow/empty API response produced constant scary `ErrorS` noise that made the cache look broken when it was not.

## What changed

**`pkg/computegardener/cache`** — new `Cache.OldestEntryAge()` accessor (age + region of the stalest entry, plus a `hasData` flag) and a test-only `TestBackdate()` helper.

**`pkg/computegardener/scheduler.go`** — `healthCheck` now delegates carbon-cache inspection to `checkCarbonCacheHealth`, which keeps three situations distinct:

| Situation | Meaning | Behaviour |
|---|---|---|
| **Empty cache** | startup, or no fetch yet | not an error (API reachability is checked separately); only errors if the refresh worker is demonstrably failing |
| **Transient staleness** | entry > TTL old but refresh worker healthy | info log only — the next refresh or any scheduling request triggers a fresh fetch |
| **Stuck cache** | entry > 2× TTL old **and** refresh worker failing repeatedly | real error — on-demand fetches are likely failing too, so scheduling genuinely suffers |

To make "stuck" detectable, the carbon cache refresh worker now maintains a consecutive-failure counter (`recordCarbonRefreshOutcome`), reset on the first success. The worker and health check also share one clamped `carbonCacheRefreshInterval()` helper instead of two copies of the same clamp.

**Tests** — `cache_health_test.go` covers all three states plus the carbon-enabled gating through `healthCheck`, the failure-counter lifecycle (build / reset / rebuild), and `refreshCarbonCache` outcome recording end-to-end with mock data sources. `cache_test.go` covers `OldestEntryAge`.

## Verification

- `make unit-test` — all packages pass
- `gofmt` clean on all changed files
- `go vet` clean
