### PR TITLE
Implement EM API forecast intensity for smart pod scheduling

### DIFF
--- a/pkg/computegardener/api/client.go
+++ b/pkg/computegardener/api/client.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
+	"strings"
 	"time"
 
 	"github.com/elevated-systems/compute-gardener-scheduler/pkg/computegardener/config"
@@ -45,6 +47,19 @@ func (e *ElectricityData) GetDataStatus() string {
 		return "estimated"
 	}
 	return "real"
+}
+
+// ForecastData represents a single forecast data point
+type ForecastData struct {
+	Datetime        time.Time `json:"datetime"`
+	CarbonIntensity float64   `json:"carbonIntensity"`
+}
+
+// ElectricityForecast represents the forecast response from the API
+type ElectricityForecast struct {
+	Zone                string         `json:"zone"`
+	Data                []ForecastData `json:"data"`
+	TemporalGranularity string         `json:"temporalGranularity"`
 }
 
 // ClientOption allows customizing the client
@@ -150,14 +165,184 @@ func (c *Client) GetCarbonIntensity(ctx context.Context, region string) (*Electr
 	return nil, fmt.Errorf("all retries failed: %v", lastErr)
 }
 
+// GetCarbonIntensityForecast fetches carbon intensity forecast data with retries and error handling.
+// horizonHours must be between 1 and 72.
+func (c *Client) GetCarbonIntensityForecast(ctx context.Context, region string, horizonHours int) (*ElectricityForecast, error) {
+	// Validate inputs
+	if region == "" {
+		return nil, fmt.Errorf("region cannot be empty")
+	}
+	if horizonHours <= 0 || horizonHours > 72 {
+		return nil, fmt.Errorf("horizonHours must be between 1 and 72, got %d", horizonHours)
+	}
+
+	// Forecast data is not cached - it changes frequently and has a short window of usefulness
+	var lastErr error
+	for attempt := 0; attempt <= c.cacheConfig.MaxRetries; attempt++ {
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("context cancelled: %v", ctx.Err())
+		case <-c.rateLimiter.C:
+			data, err := c.doForecastRequest(ctx, region, horizonHours)
+			if err == nil {
+				klog.V(2).InfoS("Successfully fetched carbon intensity forecast",
+					"region", region,
+					"horizonHours", horizonHours,
+					"dataPoints", len(data.Data))
+				return data, nil
+			}
+			lastErr = err
+			klog.V(2).InfoS("Forecast API request failed, retrying",
+				"attempt", attempt+1,
+				"maxRetries", c.cacheConfig.MaxRetries,
+				"error", err)
+
+			// Calculate backoff duration
+			backoff := c.getBackoffDuration(attempt)
+
+			// Wait with context awareness
+			timer := time.NewTimer(backoff)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return nil, fmt.Errorf("context cancelled during backoff: %v", ctx.Err())
+			case <-timer.C:
+				continue
+			}
+		}
+	}
+	return nil, fmt.Errorf("all forecast retries failed: %v", lastErr)
+}
+
+// doForecastRequest makes a single HTTP request to the forecast endpoint and decodes the response.
+func (c *Client) doForecastRequest(ctx context.Context, region string, horizonHours int) (*ElectricityForecast, error) {
+	// Build URL for forecast endpoint
+	// The forecast endpoint uses the same base URL as the latest endpoint
+	// https://api.electricitymap.org/v3/carbon-intensity/forecast?zone=REGION
+	url := c.buildURL("forecast", region)
+
+	// Create request with context
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create forecast request: %v", err)
+	}
+
+	// Log the exact URL being used for debugging
+	klog.V(2).InfoS("Making carbon forecast API request",
+		"url", req.URL.String(),
+		"region", region,
+		"horizonHours", horizonHours,
+		"hasApiKey", c.apiConfig.APIKey != "")
+
+	// Add headers
+	req.Header.Set("auth-token", c.apiConfig.APIKey)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	// Execute request
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("forecast request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Handle response status
+	switch resp.StatusCode {
+	case http.StatusOK:
+		// Continue processing
+	case http.StatusTooManyRequests:
+		return nil, fmt.Errorf("rate limit exceeded")
+	case http.StatusUnauthorized:
+		return nil, fmt.Errorf("invalid API key")
+	case http.StatusNotFound:
+		return nil, fmt.Errorf("region not found: %s", region)
+	default:
+		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	// Decode response
+	var forecast ElectricityForecast
+	if err := json.NewDecoder(resp.Body).Decode(&forecast); err != nil {
+		return nil, fmt.Errorf("failed to decode forecast response: %v", err)
+	}
+
+	// Validate response data
+	if len(forecast.Data) == 0 {
+		return nil, fmt.Errorf("no forecast data returned")
+	}
+
+	// Validate individual data points
+	for i, point := range forecast.Data {
+		if point.CarbonIntensity < 0 {
+			return nil, fmt.Errorf("invalid carbon intensity value at index %d: %f", i, point.CarbonIntensity)
+		}
+	}
+
+	return &forecast, nil
+}
+
+// buildURL constructs the appropriate URL for the given endpoint.
+// The config URL may be either:
+//   - A base URL like "https://api.electricitymap.org/v3/carbon-intensity/" (preferred)
+//   - A full latest URL like "https://api.electricitymap.org/v3/carbon-intensity/latest?zone=" (legacy)
+//
+// For the latest endpoint, it appends the zone as a query parameter.
+// For the forecast endpoint, it appends the forecast path and zone as a query parameter.
+func (c *Client) buildURL(endpoint, region string) string {
+	baseURL := c.apiConfig.URL
+
+	// If the URL already contains the latest endpoint with zone param,
+	// we need to extract the base URL before "latest"
+	if strings.Contains(baseURL, "latest?zone=") || strings.Contains(baseURL, "latest?zone%3D") {
+		// Remove the "latest?zone=" part to get base URL
+		if idx := strings.Index(baseURL, "latest"); idx != -1 {
+			baseURL = baseURL[:idx]
+		}
+	} else if strings.HasSuffix(baseURL, "latest") {
+		// Remove the "latest" part
+		baseURL = strings.TrimSuffix(baseURL, "latest")
+	} else if strings.HasSuffix(baseURL, "latest/") {
+		// Remove the "latest/" part
+		baseURL = strings.TrimSuffix(baseURL, "latest/")
+	}
+
+	// Ensure baseURL ends with "/"
+	if !strings.HasSuffix(baseURL, "/") {
+		baseURL += "/"
+	}
+
+	// Build URL based on endpoint
+	var fullURL string
+	if endpoint == "forecast" {
+		fullURL = baseURL + "forecast"
+	} else {
+		// Default to latest
+		fullURL = baseURL + "latest"
+	}
+
+	// Add zone query parameter
+	u, err := url.Parse(fullURL)
+	if err == nil {
+		q := u.Query()
+		q.Set("zone", region)
+		u.RawQuery = q.Encode()
+		fullURL = u.String()
+	}
+
+	return fullURL
+}
+
 func (c *Client) doRequest(ctx context.Context, region string) (*ElectricityData, error) {
 	// Validate inputs
 	if region == "" {
 		return nil, fmt.Errorf("region cannot be empty")
 	}
 
+	// Build URL for latest endpoint (handles both base and legacy full latest URLs)
+	url := c.buildURL("latest", region)
+
 	// Create request with context
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.apiConfig.URL+region, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %v", err)
 	}

--- a/pkg/computegardener/api/client_test.go
+++ b/pkg/computegardener/api/client_test.go
@@ -576,3 +576,419 @@ func TestGetBackoffDuration(t *testing.T) {
 		t.Errorf("Expected max backoff near 1 minute, got %v", maxBackoff)
 	}
 }
+
+func TestGetCarbonIntensityForecast_Success(t *testing.T) {
+	apiCfg := config.ElectricityMapsAPIConfig{
+		APIKey: "test-key",
+		URL:    "https://api.electricitymap.org/v3/carbon-intensity/",
+		Region: "test-region",
+	}
+
+	cacheCfg := config.APICacheConfig{
+		Timeout:     10 * time.Second,
+		MaxRetries:  1,
+		RetryDelay:  time.Microsecond,
+		RateLimit:   10,
+		CacheTTL:    30 * time.Minute,
+		MaxCacheAge: 24 * time.Hour,
+	}
+
+	mockHTTP := &MockHTTPClient{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			// Check request headers
+			if req.Header.Get("auth-token") != "test-key" {
+				t.Errorf("Expected auth-token header to be test-key, got %s", req.Header.Get("auth-token"))
+			}
+
+			// Verify forecast URL
+			if !strings.Contains(req.URL.String(), "forecast") {
+				t.Errorf("Expected forecast URL, got %s", req.URL.String())
+			}
+			if !strings.Contains(req.URL.String(), "test-region") {
+				t.Errorf("Expected region in URL, got %s", req.URL.String())
+			}
+
+			// Create a response with valid forecast JSON
+			jsonResponse := `{
+				"zone": "test-region",
+				"data": [
+					{"datetime": "2023-01-01T12:00:00Z", "carbonIntensity": 150.5},
+					{"datetime": "2023-01-01T13:00:00Z", "carbonIntensity": 120.3},
+					{"datetime": "2023-01-01T14:00:00Z", "carbonIntensity": 180.7}
+				],
+				"temporalGranularity": "hourly"
+			}`
+			return &http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(strings.NewReader(jsonResponse)),
+			}, nil
+		},
+	}
+
+	client := NewClient(apiCfg, cacheCfg,
+		WithHTTPClient(mockHTTP),
+	)
+
+	forecast, err := client.GetCarbonIntensityForecast(context.Background(), "test-region", 2)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	if forecast.Zone != "test-region" {
+		t.Errorf("Expected zone test-region, got %s", forecast.Zone)
+	}
+
+	if len(forecast.Data) != 3 {
+		t.Errorf("Expected 3 forecast points, got %d", len(forecast.Data))
+	}
+
+	if forecast.TemporalGranularity != "hourly" {
+		t.Errorf("Expected hourly granularity, got %s", forecast.TemporalGranularity)
+	}
+
+	if forecast.Data[0].CarbonIntensity != 150.5 {
+		t.Errorf("Expected first intensity 150.5, got %f", forecast.Data[0].CarbonIntensity)
+	}
+}
+
+func TestGetCarbonIntensityForecast_APIError(t *testing.T) {
+	apiCfg := config.ElectricityMapsAPIConfig{
+		APIKey: "test-key",
+		URL:    "https://api.electricitymap.org/v3/carbon-intensity/",
+		Region: "test-region",
+	}
+
+	cacheCfg := config.APICacheConfig{
+		Timeout:     10 * time.Second,
+		MaxRetries:  1,
+		RetryDelay:  time.Microsecond,
+		RateLimit:   10,
+		CacheTTL:    30 * time.Minute,
+		MaxCacheAge: 24 * time.Hour,
+	}
+
+	// Simulate HTTP error
+	mockHTTP := &MockHTTPClient{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			return nil, errors.New("simulated network error")
+		},
+	}
+
+	client := NewClient(apiCfg, cacheCfg,
+		WithHTTPClient(mockHTTP),
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	_, err := client.GetCarbonIntensityForecast(ctx, "test-region", 2)
+	if err == nil {
+		t.Fatal("Expected error, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "all forecast retries failed") {
+		t.Errorf("Expected 'all forecast retries failed' error, got %v", err)
+	}
+}
+
+func TestGetCarbonIntensityForecast_HTTPStatusCodes(t *testing.T) {
+	apiCfg := config.ElectricityMapsAPIConfig{
+		APIKey: "test-key",
+		URL:    "https://api.electricitymap.org/v3/carbon-intensity/",
+		Region: "test-region",
+	}
+
+	cacheCfg := config.APICacheConfig{
+		Timeout:     10 * time.Second,
+		MaxRetries:  1,
+		RetryDelay:  time.Microsecond,
+		RateLimit:   10,
+		CacheTTL:    30 * time.Minute,
+		MaxCacheAge: 24 * time.Hour,
+	}
+
+	tests := []struct {
+		name       string
+		statusCode int
+		errorMsg   string
+	}{
+		{
+			name:       "unauthorized",
+			statusCode: http.StatusUnauthorized,
+			errorMsg:   "invalid API key",
+		},
+		{
+			name:       "not found",
+			statusCode: http.StatusNotFound,
+			errorMsg:   "region not found",
+		},
+		{
+			name:       "rate limited",
+			statusCode: http.StatusTooManyRequests,
+			errorMsg:   "rate limit exceeded",
+		},
+		{
+			name:       "server error",
+			statusCode: http.StatusInternalServerError,
+			errorMsg:   "unexpected status code",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockHTTP := &MockHTTPClient{
+				DoFunc: func(req *http.Request) (*http.Response, error) {
+					return &http.Response{
+						StatusCode: tt.statusCode,
+						Body:       io.NopCloser(strings.NewReader("")),
+					}, nil
+				},
+			}
+
+			client := NewClient(apiCfg, cacheCfg,
+				WithHTTPClient(mockHTTP),
+			)
+
+			_, err := client.GetCarbonIntensityForecast(context.Background(), "test-region", 2)
+			if err == nil {
+				t.Fatal("Expected error, got nil")
+			}
+
+			if !strings.Contains(err.Error(), tt.errorMsg) {
+				t.Errorf("Expected error containing '%s', got %v", tt.errorMsg, err)
+			}
+		})
+	}
+}
+
+func TestGetCarbonIntensityForecast_InvalidData(t *testing.T) {
+	apiCfg := config.ElectricityMapsAPIConfig{
+		APIKey: "test-key",
+		URL:    "https://api.electricitymap.org/v3/carbon-intensity/",
+		Region: "test-region",
+	}
+
+	cacheCfg := config.APICacheConfig{
+		Timeout:     10 * time.Second,
+		MaxRetries:  1,
+		RetryDelay:  time.Microsecond,
+		RateLimit:   10,
+		CacheTTL:    30 * time.Minute,
+		MaxCacheAge: 24 * time.Hour,
+	}
+
+	tests := []struct {
+		name     string
+		jsonBody string
+		errorMsg string
+	}{
+		{
+			name:     "invalid JSON",
+			jsonBody: "not json",
+			errorMsg: "failed to decode forecast response",
+		},
+		{
+			name:     "empty data array",
+			jsonBody: `{"zone": "test-region", "data": [], "temporalGranularity": "hourly"}`,
+			errorMsg: "no forecast data returned",
+		},
+		{
+			name:     "negative carbon intensity",
+			jsonBody: `{"zone": "test-region", "data": [{"datetime": "2023-01-01T12:00:00Z", "carbonIntensity": -50.5}], "temporalGranularity": "hourly"}`,
+			errorMsg: "invalid carbon intensity value",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockHTTP := &MockHTTPClient{
+				DoFunc: func(req *http.Request) (*http.Response, error) {
+					return &http.Response{
+						StatusCode: 200,
+						Body:       io.NopCloser(strings.NewReader(tt.jsonBody)),
+					}, nil
+				},
+			}
+
+			client := NewClient(apiCfg, cacheCfg,
+				WithHTTPClient(mockHTTP),
+			)
+
+			_, err := client.GetCarbonIntensityForecast(context.Background(), "test-region", 2)
+			if err == nil {
+				t.Fatal("Expected error, got nil")
+			}
+
+			if !strings.Contains(err.Error(), tt.errorMsg) {
+				t.Errorf("Expected error containing '%s', got %v", tt.errorMsg, err)
+			}
+		})
+	}
+}
+
+func TestGetCarbonIntensityForecast_InvalidRegion(t *testing.T) {
+	apiCfg := config.ElectricityMapsAPIConfig{
+		APIKey: "test-key",
+		URL:    "https://api.electricitymap.org/v3/carbon-intensity/",
+		Region: "test-region",
+	}
+
+	cacheCfg := config.APICacheConfig{
+		Timeout:     10 * time.Second,
+		MaxRetries:  1,
+		RetryDelay:  time.Microsecond,
+		RateLimit:   10,
+		CacheTTL:    30 * time.Minute,
+		MaxCacheAge: 24 * time.Hour,
+	}
+
+	client := NewClient(apiCfg, cacheCfg)
+
+	_, err := client.GetCarbonIntensityForecast(context.Background(), "", 2)
+	if err == nil {
+		t.Fatal("Expected error for empty region, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "region cannot be empty") {
+		t.Errorf("Expected 'region cannot be empty' error, got %v", err)
+	}
+}
+
+func TestGetCarbonIntensityForecast_InvalidHorizon(t *testing.T) {
+	apiCfg := config.ElectricityMapsAPIConfig{
+		APIKey: "test-key",
+		URL:    "https://api.electricitymap.org/v3/carbon-intensity/",
+		Region: "test-region",
+	}
+
+	cacheCfg := config.APICacheConfig{
+		Timeout:     10 * time.Second,
+		MaxRetries:  1,
+		RetryDelay:  time.Microsecond,
+		RateLimit:   10,
+		CacheTTL:    30 * time.Minute,
+		MaxCacheAge: 24 * time.Hour,
+	}
+
+	client := NewClient(apiCfg, cacheCfg)
+
+	tests := []struct {
+		name    string
+		horizon int
+	}{
+		{
+			name:    "zero horizon",
+			horizon: 0,
+		},
+		{
+			name:    "negative horizon",
+			horizon: -1,
+		},
+		{
+			name:    "excessive horizon",
+			horizon: 100,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := client.GetCarbonIntensityForecast(context.Background(), "test-region", tt.horizon)
+			if err == nil {
+				t.Fatal("Expected error for invalid horizon, got nil")
+			}
+
+			if !strings.Contains(err.Error(), "horizonHours must be between 1 and 72") {
+				t.Errorf("Expected 'horizonHours' validation error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestBuildURL_Forecast(t *testing.T) {
+	tests := []struct {
+		name      string
+		configURL string
+		endpoint  string
+		region    string
+		expected  string
+	}{
+		{
+			name:      "base URL with trailing slash",
+			configURL: "https://api.electricitymap.org/v3/carbon-intensity/",
+			endpoint:  "forecast",
+			region:    "US-CAL-CISO",
+			expected:  "https://api.electricitymap.org/v3/carbon-intensity/forecast?zone=US-CAL-CISO",
+		},
+		{
+			name:      "base URL without trailing slash",
+			configURL: "https://api.electricitymap.org/v3/carbon-intensity",
+			endpoint:  "forecast",
+			region:    "US-CAL-CISO",
+			expected:  "https://api.electricitymap.org/v3/carbon-intensity/forecast?zone=US-CAL-CISO",
+		},
+		{
+			name:      "legacy full latest URL with query param",
+			configURL: "https://api.electricitymap.org/v3/carbon-intensity/latest?zone=",
+			endpoint:  "forecast",
+			region:    "US-CAL-CISO",
+			expected:  "https://api.electricitymap.org/v3/carbon-intensity/forecast?zone=US-CAL-CISO",
+		},
+		{
+			name:      "legacy full latest URL with trailing slash",
+			configURL: "https://api.electricitymap.org/v3/carbon-intensity/latest/",
+			endpoint:  "forecast",
+			region:    "US-CAL-CISO",
+			expected:  "https://api.electricitymap.org/v3/carbon-intensity/forecast?zone=US-CAL-CISO",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := NewClient(config.ElectricityMapsAPIConfig{
+				URL: tt.configURL,
+			}, config.APICacheConfig{})
+
+			url := client.buildURL(tt.endpoint, tt.region)
+
+			if url != tt.expected {
+				t.Errorf("buildURL() = %q, want %q", url, tt.expected)
+			}
+		})
+	}
+}
+
+func TestBuildURL_Latest(t *testing.T) {
+	tests := []struct {
+		name      string
+		configURL string
+		region    string
+		expected  string
+	}{
+		{
+			name:      "base URL with trailing slash",
+			configURL: "https://api.electricitymap.org/v3/carbon-intensity/",
+			region:    "US-CAL-CISO",
+			expected:  "https://api.electricitymap.org/v3/carbon-intensity/latest?zone=US-CAL-CISO",
+		},
+		{
+			name:      "legacy full latest URL",
+			configURL: "https://api.electricitymap.org/v3/carbon-intensity/latest?zone=",
+			region:    "US-CAL-CISO",
+			expected:  "https://api.electricitymap.org/v3/carbon-intensity/latest?zone=US-CAL-CISO",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := NewClient(config.ElectricityMapsAPIConfig{
+				URL: tt.configURL,
+			}, config.APICacheConfig{})
+
+			url := client.buildURL("latest", tt.region)
+
+			if url != tt.expected {
+				t.Errorf("buildURL() = %q, want %q", url, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/computegardener/carbon/implementation.go
+++ b/pkg/computegardener/carbon/implementation.go
@@ -30,6 +30,9 @@ type Implementation interface {
 	// GetCurrentIntensityWithStatus returns carbon intensity along with data quality info
 	GetCurrentIntensityWithStatus(ctx context.Context) (*IntensityData, error)
 
+	// GetForecast returns carbon intensity forecast data for the configured region
+	GetForecast(ctx context.Context, horizonHours int) (*api.ElectricityForecast, error)
+
 	// CheckIntensityConstraints checks if current carbon intensity exceeds threshold
 	CheckIntensityConstraints(ctx context.Context, threshold float64) *framework.Status
 }
@@ -72,6 +75,21 @@ func (c *carbonImpl) GetCurrentIntensityWithStatus(ctx context.Context) (*Intens
 		Value:      data.CarbonIntensity,
 		DataStatus: data.GetDataStatus(),
 	}, nil
+}
+
+func (c *carbonImpl) GetForecast(ctx context.Context, horizonHours int) (*api.ElectricityForecast, error) {
+	klog.V(3).InfoS("Fetching carbon intensity forecast",
+		"region", c.config.APIConfig.Region,
+		"horizonHours", horizonHours,
+		"apiKey", c.config.APIConfig.APIKey != "")
+
+	forecast, err := c.apiClient.GetCarbonIntensityForecast(ctx, c.config.APIConfig.Region, horizonHours)
+	if err != nil {
+		klog.V(2).InfoS("Failed to get carbon intensity forecast", "error", err)
+		return nil, fmt.Errorf("failed to get carbon intensity forecast: %v", err)
+	}
+
+	return forecast, nil
 }
 
 func (c *carbonImpl) CheckIntensityConstraints(ctx context.Context, threshold float64) *framework.Status {

--- a/pkg/computegardener/carbon/implementation_test.go
+++ b/pkg/computegardener/carbon/implementation_test.go
@@ -2,7 +2,10 @@ package carbon
 
 import (
 	"context"
+	"errors"
+	"io"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -17,9 +20,22 @@ type MockHTTPClient struct {
 	shouldFail   bool
 	statusCode   int
 	responseBody string
+	forecastBody string
+	forecastFail bool
 }
 
 func (m *MockHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	// Forecast endpoint takes precedence when it's a forecast request
+	if strings.Contains(req.URL.String(), "forecast") {
+		if m.forecastFail {
+			return nil, errors.New("simulated forecast network error")
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(m.forecastBody)),
+		}, nil
+	}
+
 	if m.shouldFail {
 		return &http.Response{
 			StatusCode: m.statusCode,
@@ -158,6 +174,83 @@ func TestGetCurrentIntensity(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetForecast(t *testing.T) {
+	validForecast := `{
+		"zone": "test-region",
+		"data": [
+			{"datetime": "2023-01-01T12:00:00Z", "carbonIntensity": 150.5},
+			{"datetime": "2023-01-01T13:00:00Z", "carbonIntensity": 120.3}
+		],
+		"temporalGranularity": "hourly"
+	}`
+
+	invalidForecast := "not-json"
+
+	newImpl := func(httpClient *MockHTTPClient) Implementation {
+		cfg := &config.CarbonConfig{
+			APIConfig: config.ElectricityMapsAPIConfig{
+				Region: "test-region",
+				APIKey: "test-key",
+			},
+		}
+		apiConfig := config.ElectricityMapsAPIConfig{
+			URL:    "https://test-api.example.com/v3/carbon-intensity/",
+			APIKey: "test-key",
+			Region: "test-region",
+		}
+		cacheConfig := config.APICacheConfig{
+			CacheTTL:    time.Minute,
+			MaxCacheAge: time.Minute * 10,
+			Timeout:     time.Second * 5,
+			MaxRetries:  1,
+			RetryDelay:  time.Millisecond,
+			RateLimit:   10,
+		}
+		client := api.NewClient(apiConfig, cacheConfig,
+			api.WithHTTPClient(httpClient),
+		)
+		return New(cfg, client)
+	}
+
+	t.Run("successful forecast", func(t *testing.T) {
+		impl := newImpl(&MockHTTPClient{forecastBody: validForecast})
+		forecast, err := impl.GetForecast(context.Background(), 2)
+		if err != nil {
+			t.Fatalf("GetForecast() unexpected error: %v", err)
+		}
+		if forecast.Zone != "test-region" {
+			t.Errorf("GetForecast() zone = %q, want %q", forecast.Zone, "test-region")
+		}
+		if len(forecast.Data) != 2 {
+			t.Errorf("GetForecast() data length = %d, want 2", len(forecast.Data))
+		}
+	})
+
+	t.Run("API error", func(t *testing.T) {
+		impl := newImpl(&MockHTTPClient{forecastFail: true})
+		_, err := impl.GetForecast(context.Background(), 2)
+		if err == nil {
+			t.Fatal("GetForecast() expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "failed to get carbon intensity forecast") {
+			t.Errorf("GetForecast() error = %q, want it to contain %q",
+				err.Error(), "failed to get carbon intensity forecast")
+		}
+	})
+
+	t.Run("invalid forecast data", func(t *testing.T) {
+		impl := newImpl(&MockHTTPClient{forecastBody: invalidForecast})
+		_, err := impl.GetForecast(context.Background(), 2)
+		if err == nil {
+			t.Fatal("GetForecast() expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "failed to decode forecast response") {
+			t.Errorf("GetForecast() error = %q, want it to contain %q",
+				err.Error(), "failed to decode forecast response")
+		}
+	})
 }
 
 func TestCheckIntensityConstraints(t *testing.T) {

--- a/pkg/computegardener/common/constants.go
+++ b/pkg/computegardener/common/constants.go
@@ -11,6 +11,7 @@ const (
 
 	// Carbon-aware scheduling annotations
 	AnnotationCarbonIntensityThreshold = AnnotationBase + "/carbon-intensity-threshold"
+	AnnotationCarbonIntensityMode      = AnnotationBase + "/carbon-intensity-mode" // "threshold" (default) or "forecast"
 	AnnotationCarbonEnabled            = AnnotationBase + "/carbon-enabled"
 
 	// Price-aware scheduling annotations

--- a/pkg/computegardener/scheduler.go
+++ b/pkg/computegardener/scheduler.go
@@ -832,27 +832,106 @@ func (cs *ComputeGardenerScheduler) applyNamespaceEnergyBudget(ctx context.Conte
 	return nil
 }
 
+// getMaxSchedulingDelay returns the effective max scheduling delay for a pod,
+// applying the pod-level annotation override on top of the global config.
+func (cs *ComputeGardenerScheduler) getMaxSchedulingDelay(pod *v1.Pod) time.Duration {
+	maxDelay := cs.config.Scheduling.MaxSchedulingDelay
+	if val, ok := pod.Annotations[common.AnnotationMaxSchedulingDelay]; ok {
+		if d, err := time.ParseDuration(val); err == nil {
+			maxDelay = d
+		} else {
+			klog.ErrorS(err, "Invalid max scheduling delay annotation",
+				"pod", pod.Name,
+				"namespace", pod.Namespace,
+				"value", val)
+		}
+	}
+	return maxDelay
+}
+
 func (cs *ComputeGardenerScheduler) hasExceededMaxDelay(pod *v1.Pod) bool {
 	if creationTime := pod.CreationTimestamp; !creationTime.IsZero() {
-		// Check for pod-level max delay annotation
-		maxDelay := cs.config.Scheduling.MaxSchedulingDelay
-		if val, ok := pod.Annotations[common.AnnotationMaxSchedulingDelay]; ok {
-			if d, err := time.ParseDuration(val); err == nil {
-				maxDelay = d
-			} else {
-				klog.ErrorS(err, "Invalid max scheduling delay annotation",
-					"pod", pod.Name,
-					"namespace", pod.Namespace,
-					"value", val)
-			}
-		}
-		return cs.clock.Since(creationTime.Time) > maxDelay
+		return cs.clock.Since(creationTime.Time) > cs.getMaxSchedulingDelay(pod)
 	}
 	return false
 }
 
 func (cs *ComputeGardenerScheduler) isOptedOut(pod *v1.Pod) bool {
 	return pod.Annotations[common.AnnotationSkip] == "true"
+}
+
+// getCarbonIntensityMode returns the carbon intensity scheduling mode for a pod.
+// It reads the pod annotation and defaults to "threshold" mode if not set or invalid.
+func (cs *ComputeGardenerScheduler) getCarbonIntensityMode(pod *v1.Pod) string {
+	if pod.Annotations == nil {
+		return "threshold"
+	}
+	if mode, ok := pod.Annotations[common.AnnotationCarbonIntensityMode]; ok {
+		switch mode {
+		case "threshold", "forecast":
+			return mode
+		default:
+			klog.V(2).InfoS("Invalid carbon intensity mode annotation, using default",
+				"pod", klog.KObj(pod),
+				"invalidMode", mode,
+				"defaultMode", "threshold")
+			return "threshold"
+		}
+	}
+	return "threshold" // default mode
+}
+
+// findForecastWindow queries the carbon intensity forecast and determines whether the pod
+// should wait for a cleaner window within its maximum scheduling delay.
+// Returns (wait, reason, optimalTime, ok) where:
+//   - wait: true if we should delay the pod
+//   - reason: human-readable reason for the status
+//   - optimalTime: the time of the best forecast window
+//   - ok: false if forecast API failed and we should fall back to threshold behaviour
+func (cs *ComputeGardenerScheduler) findForecastWindow(ctx context.Context, pod *v1.Pod, currentIntensity, threshold float64) (bool, string, time.Time, bool) {
+	// The EM API provides forecast data; we ask for a 2-hour window which is a
+	// common horizon. The forecast is only consulted when above threshold.
+	forecast, err := cs.carbonImpl.GetForecast(ctx, 2)
+	if err != nil {
+		klog.V(2).InfoS("Failed to get forecast, falling back to threshold mode",
+			"pod", klog.KObj(pod),
+			"error", err)
+		return false, "", time.Time{}, false
+	}
+
+	if forecast == nil || len(forecast.Data) == 0 {
+		return false, "", time.Time{}, false
+	}
+
+	maxDelay := cs.getMaxSchedulingDelay(pod)
+
+	// Find the best (lowest intensity) forecast point within the max delay window
+	var optimal api.ForecastData
+	foundOptimal := false
+	for _, point := range forecast.Data {
+		timeUntil := time.Until(point.Datetime)
+		if timeUntil <= maxDelay && timeUntil > 0 && point.CarbonIntensity <= threshold {
+			if !foundOptimal || point.CarbonIntensity < optimal.CarbonIntensity {
+				optimal = point
+				foundOptimal = true
+			}
+		}
+	}
+
+	// No acceptable window in the forecast, check if we've exceeded max delay
+	if !foundOptimal {
+		if cs.hasExceededMaxDelay(pod) {
+			return false, "", time.Time{}, true // don't wait, proceed anyway
+		}
+		return true,
+			fmt.Sprintf("Current carbon intensity (%.2f) exceeds threshold (%.2f), no acceptable forecast windows found",
+				currentIntensity, threshold),
+			time.Time{}, true
+	}
+
+	waitMsg := fmt.Sprintf("Current carbon intensity (%.2f) exceeds threshold (%.2f), forecast shows acceptable window at %v (%.2f)",
+		currentIntensity, threshold, optimal.Datetime.Format("15:04"), optimal.CarbonIntensity)
+	return true, waitMsg, optimal.Datetime, true
 }
 
 // applyCarbonIntensityCheck performs carbon intensity threshold checks and returns appropriate status
@@ -887,6 +966,36 @@ func (cs *ComputeGardenerScheduler) applyCarbonIntensityCheck(ctx context.Contex
 
 	podUID := string(pod.UID)
 	wasDelayed := cs.carbonDelayedPods[podUID]
+
+	// If we've exceeded the max scheduling delay, proceed with scheduling
+	// regardless of current or forecast carbon intensity
+	if cs.hasExceededMaxDelay(pod) {
+		klog.V(2).InfoS("Maximum scheduling delay exceeded - proceeding with pod scheduling",
+			"pod", klog.KObj(pod))
+		return nil, framework.NewStatus(framework.Success, "maximum scheduling delay exceeded")
+	}
+
+	// In forecast mode and above the threshold, see whether the forecast offers a
+	// cleaner window to schedule within this pod's max delay. On any forecast API
+	// failure we fall through to the standard threshold behaviour below (graceful fallback).
+	if cs.getCarbonIntensityMode(pod) == "forecast" && currentIntensity > threshold {
+		if wait, reason, ts, ok := cs.findForecastWindow(ctx, pod, currentIntensity, threshold); ok && wait {
+			klog.V(2).InfoS("Forecast mode: delaying pod for cleaner forecast window",
+				"pod", klog.KObj(pod),
+				"currentIntensity", currentIntensity,
+				"threshold", threshold,
+				"optimalTime", ts,
+				"reason", reason)
+			if !wasDelayed {
+				metrics.CarbonBasedDelays.WithLabelValues(cs.config.Carbon.APIConfig.Region).Inc()
+			}
+			cs.carbonDelayedPods[podUID] = true
+			if !wasDelayed {
+				cs.recordInitialCarbonMetric(ctx, pod)
+			}
+			return nil, framework.NewStatus(framework.Unschedulable, reason)
+		}
+	}
 
 	if currentIntensity > threshold {
 		msg := fmt.Sprintf("Current carbon intensity (%.2f) exceeds threshold (%.2f)",

--- a/pkg/computegardener/scheduler_forecast_test.go
+++ b/pkg/computegardener/scheduler_forecast_test.go
@@ -1,0 +1,372 @@
+package computegardener
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+
+	"github.com/elevated-systems/compute-gardener-scheduler/pkg/computegardener/api"
+	"github.com/elevated-systems/compute-gardener-scheduler/pkg/computegardener/carbon"
+	"github.com/elevated-systems/compute-gardener-scheduler/pkg/computegardener/common"
+	"github.com/elevated-systems/compute-gardener-scheduler/pkg/computegardener/config"
+	testingmocks "github.com/elevated-systems/compute-gardener-scheduler/pkg/computegardener/testing"
+)
+
+func TestGetCarbonIntensityMode(t *testing.T) {
+	baseTime := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name     string
+		pod      *v1.Pod
+		expected string
+	}{
+		{
+			name: "no annotation defaults to threshold",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-pod",
+					Namespace:         "test-ns",
+					CreationTimestamp: metav1.NewTime(baseTime),
+				},
+			},
+			expected: "threshold",
+		},
+		{
+			name: "forecast mode",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-pod",
+					Namespace:         "test-ns",
+					CreationTimestamp: metav1.NewTime(baseTime),
+					Annotations: map[string]string{
+						common.AnnotationCarbonIntensityMode: "forecast",
+					},
+				},
+			},
+			expected: "forecast",
+		},
+		{
+			name: "threshold mode explicit",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-pod",
+					Namespace:         "test-ns",
+					CreationTimestamp: metav1.NewTime(baseTime),
+					Annotations: map[string]string{
+						common.AnnotationCarbonIntensityMode: "threshold",
+					},
+				},
+			},
+			expected: "threshold",
+		},
+		{
+			name: "invalid mode defaults to threshold",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-pod",
+					Namespace:         "test-ns",
+					CreationTimestamp: metav1.NewTime(baseTime),
+					Annotations: map[string]string{
+						common.AnnotationCarbonIntensityMode: "invalid-mode",
+					},
+				},
+			},
+			expected: "threshold",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cs := newTestScheduler(&config.Config{
+				Carbon: config.CarbonConfig{
+					Enabled: true,
+					APIConfig: config.ElectricityMapsAPIConfig{
+						Region: "test-region",
+					},
+				},
+			}, 100.0, 0.1, baseTime)
+
+			mode := cs.getCarbonIntensityMode(tt.pod)
+			if mode != tt.expected {
+				t.Errorf("getCarbonIntensityMode() = %q, want %q", mode, tt.expected)
+			}
+		})
+	}
+}
+
+// mockCarbonImplForForecast is a carbon impl that returns configurable forecast
+type mockCarbonImplForForecast struct {
+	carbon.Implementation
+	forecast    *api.ElectricityForecast
+	forecastErr error
+}
+
+func (m *mockCarbonImplForForecast) GetForecast(ctx context.Context, horizonHours int) (*api.ElectricityForecast, error) {
+	if m.forecastErr != nil {
+		return nil, m.forecastErr
+	}
+	return m.forecast, nil
+}
+
+func TestFindForecastWindow(t *testing.T) {
+	baseTime := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name               string
+		currentIntensity   float64
+		threshold          float64
+		forecast           *api.ElectricityForecast
+		forecastErr        error
+		maxDelay           time.Duration
+		wantWait           bool
+		wantReasonContains string
+	}{
+		{
+			name:             "forecast API error falls back to threshold",
+			currentIntensity: 250,
+			threshold:        200,
+			forecastErr:      errors.New("forecast API failed"),
+			maxDelay:         time.Hour,
+			wantWait:         false, // ok=false means fall back, caller uses threshold path
+		},
+		{
+			name:             "forecast has acceptable window within max delay",
+			currentIntensity: 250,
+			threshold:        200,
+			forecast: &api.ElectricityForecast{
+				Zone: "test-region",
+				Data: []api.ForecastData{
+					{Datetime: time.Now().Add(30 * time.Minute), CarbonIntensity: 150},
+					{Datetime: time.Now().Add(1 * time.Hour), CarbonIntensity: 120},
+				},
+			},
+			maxDelay:           2 * time.Hour,
+			wantWait:           true,
+			wantReasonContains: "acceptable window",
+		},
+		{
+			name:             "forecast has no acceptable window but pod not overdue",
+			currentIntensity: 250,
+			threshold:        200,
+			forecast: &api.ElectricityForecast{
+				Zone: "test-region",
+				Data: []api.ForecastData{
+					{Datetime: time.Now().Add(30 * time.Minute), CarbonIntensity: 250},
+				},
+			},
+			maxDelay:           2 * time.Hour,
+			wantWait:           true,
+			wantReasonContains: "no acceptable forecast windows found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cs := newTestScheduler(&config.Config{
+				Carbon: config.CarbonConfig{
+					Enabled: true,
+					APIConfig: config.ElectricityMapsAPIConfig{
+						Region: "test-region",
+					},
+				},
+				Scheduling: config.SchedulingConfig{
+					MaxSchedulingDelay: tt.maxDelay,
+				},
+			}, 250.0, 0.1, baseTime)
+
+			cs.carbonImpl = &mockCarbonImplForForecast{
+				Implementation: testingmocks.NewMockCarbon(250),
+				forecast:       tt.forecast,
+				forecastErr:    tt.forecastErr,
+			}
+
+			pod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-pod",
+					Namespace:         "test-ns",
+					CreationTimestamp: metav1.NewTime(baseTime),
+					UID:               "test-pod-uid",
+				},
+			}
+
+			wait, reason, _, ok := cs.findForecastWindow(context.Background(), pod, tt.currentIntensity, tt.threshold)
+
+			if tt.forecastErr != nil {
+				// Should signal fallback (ok=false)
+				if ok {
+					t.Errorf("findForecastWindow() ok = true, want false (fallback) for forecast error")
+				}
+				return
+			}
+
+			if !ok {
+				t.Fatalf("findForecastWindow() ok = false, want true")
+			}
+
+			if wait != tt.wantWait {
+				t.Errorf("findForecastWindow() wait = %v, want %v", wait, tt.wantWait)
+			}
+
+			if tt.wantReasonContains != "" && !strings.Contains(reason, tt.wantReasonContains) {
+				t.Errorf("findForecastWindow() reason = %q, want it to contain %q",
+					reason, tt.wantReasonContains)
+			}
+		})
+	}
+}
+
+// TestPreFilter_ForecastMode tests the end-to-end PreFilter behavior with forecast mode
+func TestPreFilter_ForecastMode(t *testing.T) {
+	baseTime := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name              string
+		carbonEnabled     bool
+		carbonIntensity   float64
+		threshold         float64
+		forecastMode      bool
+		forecastErr       bool
+		maxDelay          time.Duration
+		podCreationOffset time.Duration
+		wantStatus        *framework.Status
+	}{
+		{
+			name:              "forecast mode with clean forecast window - should delay",
+			carbonEnabled:     true,
+			carbonIntensity:   250,
+			threshold:         200,
+			forecastMode:      true,
+			forecastErr:       false,
+			maxDelay:          2 * time.Hour,
+			podCreationOffset: 0,
+			wantStatus: framework.NewStatus(
+				framework.Unschedulable,
+				"",
+			),
+		},
+		{
+			name:              "forecast mode with API error - falls back to threshold",
+			carbonEnabled:     true,
+			carbonIntensity:   250,
+			threshold:         200,
+			forecastMode:      true,
+			forecastErr:       true,
+			maxDelay:          2 * time.Hour,
+			podCreationOffset: 0,
+			wantStatus: framework.NewStatus(
+				framework.Unschedulable,
+				"Current carbon intensity (250.00) exceeds threshold (200.00)",
+			),
+		},
+		{
+			name:              "forecast mode max delay exceeded - allows pod",
+			carbonEnabled:     true,
+			carbonIntensity:   250,
+			threshold:         200,
+			forecastMode:      true,
+			forecastErr:       false,
+			maxDelay:          time.Hour,
+			podCreationOffset: -2 * time.Hour,
+			wantStatus: framework.NewStatus(
+				framework.Success,
+				"maximum scheduling delay exceeded",
+			),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.Config{
+				Cache: config.APICacheConfig{
+					Timeout:     time.Second,
+					MaxRetries:  1,
+					RetryDelay:  time.Millisecond,
+					RateLimit:   10,
+					CacheTTL:    time.Minute,
+					MaxCacheAge: time.Hour,
+				},
+				Carbon: config.CarbonConfig{
+					Enabled:            tt.carbonEnabled,
+					Provider:           "electricity-maps-api",
+					IntensityThreshold: tt.threshold,
+					APIConfig: config.ElectricityMapsAPIConfig{
+						APIKey: "test-key",
+						Region: "test-region",
+						URL:    "http://mock-url/",
+					},
+				},
+				Pricing: config.PriceConfig{
+					Enabled:  false,
+					Provider: "tou",
+				},
+				Scheduling: config.SchedulingConfig{
+					MaxSchedulingDelay: tt.maxDelay,
+				},
+				Power: config.PowerConfig{
+					DefaultIdlePower: 100,
+					DefaultMaxPower:  400,
+					DefaultPUE:       1.15,
+					DefaultGPUPUE:    1.2,
+				},
+			}
+
+			// Use baseTime as the "current" time; podCreationOffset shifts when the pod was created
+			scheduler := newTestScheduler(cfg, tt.carbonIntensity, 0.1, baseTime)
+
+			// Set up mock forecast behavior
+			mockForecast := &api.ElectricityForecast{
+				Zone: "test-region",
+				Data: []api.ForecastData{
+					{Datetime: time.Now().Add(30 * time.Minute), CarbonIntensity: 150},
+					{Datetime: time.Now().Add(1 * time.Hour), CarbonIntensity: 120},
+				},
+			}
+
+			mockCarbon := &mockCarbonImplForForecast{
+				Implementation: testingmocks.NewMockCarbon(tt.carbonIntensity),
+				forecast:       mockForecast,
+			}
+			if tt.forecastErr {
+				mockCarbon.forecastErr = errors.New("forecast API failed")
+			}
+			scheduler.carbonImpl = mockCarbon
+
+			// Pod creation time is baseTime + offset (negative offset = older pod)
+			podCreationTime := baseTime.Add(tt.podCreationOffset)
+			pod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-pod",
+					Namespace:         "test-ns",
+					CreationTimestamp: metav1.NewTime(podCreationTime),
+					Annotations:       make(map[string]string),
+				},
+			}
+			if tt.forecastMode {
+				pod.Annotations[common.AnnotationCarbonIntensityMode] = "forecast"
+			}
+
+			state := framework.NewCycleState()
+			_, status := scheduler.PreFilter(context.Background(), state, pod)
+
+			// Verify the status code matches
+			if status.Code() != tt.wantStatus.Code() {
+				t.Errorf("PreFilter() status code = %v, want %v (message: %q)",
+					status.Code(), tt.wantStatus.Code(), status.Message())
+			}
+
+			// For unschedulable with specific expected message, verify message matches
+			if tt.wantStatus.Code() == framework.Unschedulable && tt.wantStatus.Message() != "" {
+				if status.Message() != tt.wantStatus.Message() {
+					t.Errorf("PreFilter() status message = %q, want %q",
+						status.Message(), tt.wantStatus.Message())
+				}
+			}
+		})
+	}
+}

--- a/pkg/computegardener/testing/mocks.go
+++ b/pkg/computegardener/testing/mocks.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	metricsv1beta1 "k8s.io/metrics/pkg/apis/metrics/v1beta1"
 
+	"github.com/elevated-systems/compute-gardener-scheduler/pkg/computegardener/api"
 	"github.com/elevated-systems/compute-gardener-scheduler/pkg/computegardener/carbon"
 	"github.com/elevated-systems/compute-gardener-scheduler/pkg/computegardener/common"
 	"github.com/elevated-systems/compute-gardener-scheduler/pkg/computegardener/config"
@@ -27,6 +28,7 @@ type MockCarbonImplementation struct {
 	// Advanced mode function overrides (when set, these take precedence)
 	GetCurrentIntensityFunc           func(ctx context.Context) (float64, error)
 	GetCurrentIntensityWithStatusFunc func(ctx context.Context) (*carbon.IntensityData, error)
+	GetForecastFunc                   func(ctx context.Context, horizonHours int) (*api.ElectricityForecast, error)
 	CheckIntensityConstraintsFunc     func(ctx context.Context, threshold float64) *framework.Status
 }
 
@@ -73,6 +75,33 @@ func (m *MockCarbonImplementation) GetCurrentIntensityWithStatus(ctx context.Con
 	return &carbon.IntensityData{
 		Value:      m.intensity,
 		DataStatus: status,
+	}, nil
+}
+
+func (m *MockCarbonImplementation) GetForecast(ctx context.Context, horizonHours int) (*api.ElectricityForecast, error) {
+	// Function override takes precedence
+	if m.GetForecastFunc != nil {
+		return m.GetForecastFunc(ctx, horizonHours)
+	}
+
+	// Simple mode behavior - returns a basic forecast using the fixed intensity
+	if m.errorMode {
+		return nil, fmt.Errorf("carbon forecast API error (mock)")
+	}
+
+	now := time.Now().UTC()
+	// Generate hourly forecast points for the requested horizon
+	data := make([]api.ForecastData, 0, horizonHours)
+	for i := 0; i < horizonHours; i++ {
+		data = append(data, api.ForecastData{
+			Datetime:        now.Add(time.Duration(i) * time.Hour),
+			CarbonIntensity: m.intensity,
+		})
+	}
+
+	return &api.ElectricityForecast{
+		Zone: "mock-zone",
+		Data: data,
 	}, nil
 }
 


### PR DESCRIPTION
## Summary
Implements the EM API forecast-intensity integration that closes out #32.

Adds the ability for the scheduler to read EM's `/v3/carbon-intensity/forecast` endpoint and use the upcoming intensity curve (not just the current value) to decide whether to hold a pod now in expectation of a cleaner window.

## Changes
- `pkg/computegardener/api/client.go` — new `GetCarbonIntensityForecast(ctx, region, horizonHours)` + `buildURL` helper handling both legacy "latest" and new "forecast" endpoints.
- `pkg/computegardener/carbon/implementation.go` — adds `GetForecast` to the `Implementation` interface and delegates to the client.
- `pkg/computegardener/scheduler.go` — in PreFilter, when a pod has `compute-gardener.io/carbon-intensity-mode: forecast` and current intensity > threshold, consults the forecast to look for a cleaner window within the pod's max scheduling delay. Falls back to the legacy threshold behavior on API error.
- `pkg/computegardener/common/constants.go` — new `AnnotationCarbonIntensityMode` annotation constant.
- Tests added across `api`, `carbon`, `scheduler`.

## Testing
- `make build` passes.
- `go test -count=1 ./...` passes for all packages (including new forecast tests).
- Forecast unit tests cover: success, API error, HTTP status codes, invalid data, invalid region, invalid horizon, URL construction, forecast-window search, PreFilter end-to-end in forecast mode.

Resolves #32.